### PR TITLE
feat(book): refactor serial number input with manual entry and auto search

### DIFF
--- a/app/components/book/BarcodeScanner.vue
+++ b/app/components/book/BarcodeScanner.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { BrowserMultiFormatReader } from '@zxing/library'
-import type { TabsItem } from '@nuxt/ui'
 
 const emit = defineEmits<{
   scanned: [value: string]
@@ -8,13 +7,7 @@ const emit = defineEmits<{
 }>()
 
 const open = ref(false)
-const activeTab = ref('scan')
-const tabItems = ref<TabsItem[]>([
-  { label: 'Scan', icon: 'i-lucide-scan-barcode', value: 'scan' },
-  { label: 'Cari', icon: 'i-lucide-search', value: 'manual' },
-])
 
-// ─── Scan tab state ───────────────────────────────────────────────────────────
 const barcodeLoading = ref(false)
 const cameraError = ref('')
 const scanning = ref(false)
@@ -22,9 +15,6 @@ const videoRef = ref<HTMLVideoElement>()
 const codeReader = ref<BrowserMultiFormatReader>()
 const videoDevices = ref<MediaDeviceInfo[]>([])
 const selectedDeviceIndex = ref(0)
-
-// ─── Manual tab state ─────────────────────────────────────────────────────────
-const manualCode = ref('')
 
 onMounted(() => {
   codeReader.value = new BrowserMultiFormatReader()
@@ -86,10 +76,9 @@ const startScanning = async () => {
 
     codeReader.value.decodeFromVideoDevice(deviceId, videoRef.value, (result) => {
       if (result && scanning.value) {
-        const value = result.getText()
         stopScanning()
         closeModal()
-        emit('scanned', value)
+        emit('scanned', result.getText())
       }
     })
 
@@ -118,20 +107,10 @@ const currentCameraName = computed(() => {
   return videoDevices.value[selectedDeviceIndex.value]?.label || `Camera ${selectedDeviceIndex.value + 1}`
 })
 
-// ─── Manual submit ────────────────────────────────────────────────────────────
-function submitManual() {
-  const code = manualCode.value.trim()
-  if (!code) return
-  closeModal()
-  emit('scanned', code)
-}
-
 // ─── Modal lifecycle ──────────────────────────────────────────────────────────
 const openModal = () => {
   barcodeLoading.value = true
   cameraError.value = ''
-  manualCode.value = ''
-  activeTab.value = 'scan'
   open.value = true
 }
 
@@ -140,23 +119,11 @@ const closeModal = () => {
   open.value = false
   cameraError.value = ''
   barcodeLoading.value = false
-  manualCode.value = ''
   emit('close')
 }
 
 watch(open, (val) => {
-  if (val && activeTab.value === 'scan') {
-    nextTick(() => startScanning())
-  } else if (!val) {
-    stopScanning()
-  }
-})
-
-watch(activeTab, (val) => {
-  if (!open.value) return
-  if (val === 'scan') {
-    barcodeLoading.value = true
-    cameraError.value = ''
+  if (val) {
     nextTick(() => startScanning())
   } else {
     stopScanning()
@@ -171,110 +138,72 @@ defineExpose({ openModal })
 <template>
   <UModal
     v-model:open="open"
-    title="Cari Buku"
-    description="Cari Buku yang tersedia untuk dipinjam"
+    title="Scan Barcode"
+    description="Arahkan kamera ke barcode / QR code buku"
     @close="closeModal"
   >
     <template #body>
       <div class="space-y-4">
-        <!-- Tabs -->
-        <UTabs
-          v-model="activeTab"
-          :items="tabItems"
-          :content="false"
-          class="w-full"
-        />
-
-        <!-- ── Tab: Scan Kamera ── -->
-        <div v-if="activeTab === 'scan'">
-          <div class="relative bg-gray-900 rounded-lg overflow-hidden" style="aspect-ratio: 4/3;">
-            <video
-              v-if="open && activeTab === 'scan'"
-              ref="videoRef"
-              class="w-full h-full object-cover"
-              autoplay
-              muted
-              playsinline
-            />
-
-            <!-- Camera name badge -->
-            <div
-              v-if="!barcodeLoading && !cameraError && scanning"
-              class="absolute top-3 left-3 bg-black/60 text-white text-xs px-3 py-1.5 rounded-full"
-            >
-              {{ currentCameraName }}
-            </div>
-
-            <!-- Loading -->
-            <div
-              v-if="barcodeLoading"
-              class="absolute inset-0 flex items-center justify-center bg-gray-900/80"
-            >
-              <div class="text-center text-white">
-                <UIcon name="i-lucide-camera" class="w-12 h-12 mx-auto mb-2 animate-pulse" />
-                <p class="text-sm">Membuka kamera...</p>
-              </div>
-            </div>
-
-            <!-- Camera error -->
-            <div
-              v-if="cameraError"
-              class="absolute inset-0 flex items-center justify-center bg-red-50"
-            >
-              <div class="text-center p-4 max-w-sm">
-                <UIcon name="i-lucide-camera-off" class="w-12 h-12 text-red-500 mx-auto mb-3" />
-                <h3 class="font-semibold text-red-700 mb-2">Kamera Error</h3>
-                <p class="text-red-600 text-sm mb-4">{{ cameraError }}</p>
-                <UButton label="Coba Lagi" size="sm" icon="i-lucide-refresh-cw" @click="retryCamera" />
-              </div>
-            </div>
-
-            <!-- Scan frame overlay -->
-            <div
-              v-if="scanning && !barcodeLoading && !cameraError"
-              class="absolute inset-0 pointer-events-none flex items-center justify-center"
-            >
-              <div class="relative w-56 h-36">
-                <span class="absolute top-0 left-0 w-7 h-7 border-t-4 border-l-4 border-primary rounded-tl-sm" />
-                <span class="absolute top-0 right-0 w-7 h-7 border-t-4 border-r-4 border-primary rounded-tr-sm" />
-                <span class="absolute bottom-0 left-0 w-7 h-7 border-b-4 border-l-4 border-primary rounded-bl-sm" />
-                <span class="absolute bottom-0 right-0 w-7 h-7 border-b-4 border-r-4 border-primary rounded-br-sm" />
-                <div class="absolute inset-x-2 h-0.5 bg-primary/80 animate-[scan_2s_ease-in-out_infinite]" style="animation: scan 2s ease-in-out infinite;" />
-              </div>
-            </div>
-          </div>
-
-          <p class="text-xs text-muted text-center mt-2">
-            Arahkan kamera ke barcode / QR code buku
-          </p>
-        </div>
-
-        <!-- ── Tab: Isi Manual ── -->
-        <div v-else-if="activeTab === 'manual'" class="space-y-3 py-2">
-          <div class="flex items-center justify-center">
-            <UIcon name="i-lucide-barcode" class="w-12 h-12 text-muted" />
-          </div>
-          <p class="text-sm text-muted text-center">
-            Masukkan kode serial buku 
-          </p>
-          <UInput
-            v-model="manualCode"
-            placeholder="Contoh: N12345678BA"
-            icon="i-lucide-hash"
-            autofocus
-            size="lg"
-            class="w-full"
-            @keyup.enter="submitManual"
+        <!-- Camera view -->
+        <div class="relative bg-gray-900 rounded-lg overflow-hidden" style="aspect-ratio: 4/3;">
+          <video
+            v-if="open"
+            ref="videoRef"
+            class="w-full h-full object-cover"
+            autoplay
+            muted
+            playsinline
           />
-          <UButton
-            class="w-full justify-center"
-            :disabled="!manualCode.trim()"
-            icon="i-lucide-search"
-            @click="submitManual"
+
+          <!-- Camera name badge -->
+          <div
+            v-if="!barcodeLoading && !cameraError && scanning"
+            class="absolute top-3 left-3 bg-black/60 text-white text-xs px-3 py-1.5 rounded-full"
           >
-            Cari
-          </UButton>
+            {{ currentCameraName }}
+          </div>
+
+          <!-- Loading -->
+          <div
+            v-if="barcodeLoading"
+            class="absolute inset-0 flex items-center justify-center bg-gray-900/80"
+          >
+            <div class="text-center text-white">
+              <UIcon name="i-lucide-camera" class="w-12 h-12 mx-auto mb-2 animate-pulse" />
+              <p class="text-sm">Membuka kamera...</p>
+            </div>
+          </div>
+
+          <!-- Camera error -->
+          <div
+            v-if="cameraError"
+            class="absolute inset-0 flex items-center justify-center bg-red-50"
+          >
+            <div class="text-center p-4 max-w-sm">
+              <UIcon name="i-lucide-camera-off" class="w-12 h-12 text-red-500 mx-auto mb-3" />
+              <h3 class="font-semibold text-red-700 mb-2">Kamera Error</h3>
+              <p class="text-red-600 text-sm mb-4">{{ cameraError }}</p>
+              <UButton label="Coba Lagi" size="sm" icon="i-lucide-refresh-cw" @click="retryCamera" />
+            </div>
+          </div>
+
+          <!-- Scan frame overlay -->
+          <div
+            v-if="scanning && !barcodeLoading && !cameraError"
+            class="absolute inset-0 pointer-events-none flex items-center justify-center"
+          >
+            <div class="relative w-56 h-36">
+              <span class="absolute top-0 left-0 w-7 h-7 border-t-4 border-l-4 border-primary rounded-tl-sm" />
+              <span class="absolute top-0 right-0 w-7 h-7 border-t-4 border-r-4 border-primary rounded-tr-sm" />
+              <span class="absolute bottom-0 left-0 w-7 h-7 border-b-4 border-l-4 border-primary rounded-bl-sm" />
+              <span class="absolute bottom-0 right-0 w-7 h-7 border-b-4 border-r-4 border-primary rounded-br-sm" />
+            </div>
+          </div>
         </div>
+
+        <p class="text-xs text-muted text-center">
+          Arahkan kamera ke barcode / QR code buku
+        </p>
 
         <!-- Footer -->
         <div class="flex justify-end">

--- a/app/pages/book/pinjam.vue
+++ b/app/pages/book/pinjam.vue
@@ -98,15 +98,15 @@ const state = reactive<Partial<Schema>>({
   category: undefined,
 })
 
-async function onScanned(code: string) {
+async function lookupBySerial(code: string) {
+  if (!code?.trim()) return
   lookupLoading.value = true
-  state.serialNumber = code
   state.judulBuku = undefined
   state.category = undefined
   bookData.value = null
 
   try {
-    const res = await bookService.getBookByCode(code)
+    const res = await bookService.getBookByCode(code.trim())
     bookData.value = res.data
     state.judulBuku = res.data.name
     state.category = res.data.subCategory.name
@@ -116,10 +116,14 @@ async function onScanned(code: string) {
       description: `Tidak ada buku dengan kode "${code}"`,
       color: 'error'
     })
-    state.serialNumber = undefined
   } finally {
     lookupLoading.value = false
   }
+}
+
+function onScanned(code: string) {
+  state.serialNumber = code
+  lookupBySerial(code)
 }
 
 function resetBook() {
@@ -209,33 +213,48 @@ onUnmounted(() => stopCamera())
         <div class="flex gap-2">
           <UInput
             v-model="state.serialNumber"
-            placeholder="Scan barcode untuk mengisi"
+            placeholder="Ketik atau scan serial number"
             icon="i-lucide-hash"
             class="flex-1"
-            disabled
             :loading="lookupLoading"
-          />
-          <UButton
-            v-if="!state.serialNumber"
-            type="button"
-            variant="soft"
-            color="primary"
-            icon="i-lucide-scan-barcode"
-            class="shrink-0"
-            title="Scan Barcode"
             :disabled="lookupLoading"
-            @click="barcodeScannerRef?.openModal()"
+            @keyup.enter="lookupBySerial(state.serialNumber!)"
           />
-          <UButton
-            v-else
-            type="button"
-            variant="outline"
-            color="error"
-            icon="i-lucide-x"
-            class="shrink-0"
-            title="Reset"
-            @click="resetBook"
-          />
+          <template v-if="bookData">
+            <UButton
+              type="button"
+              variant="outline"
+              color="error"
+              icon="i-lucide-x"
+              class="shrink-0"
+              title="Reset"
+              @click="resetBook"
+            />
+          </template>
+          <template v-else>
+            <UButton
+              v-if="state.serialNumber"
+              type="button"
+              variant="soft"
+              color="primary"
+              icon="i-lucide-search"
+              class="shrink-0"
+              title="Cari Buku"
+              :loading="lookupLoading"
+              :disabled="lookupLoading"
+              @click="lookupBySerial(state.serialNumber!)"
+            />
+            <UButton
+              type="button"
+              variant="soft"
+              color="neutral"
+              icon="i-lucide-scan-barcode"
+              class="shrink-0"
+              title="Scan Barcode"
+              :disabled="lookupLoading"
+              @click="barcodeScannerRef?.openModal()"
+            />
+          </template>
         </div>
       </UFormField>
 


### PR DESCRIPTION
## Summary

- Input Serial Number tidak lagi `disabled` — pengguna bisa mengetik kode secara manual
- Tambah tombol **Search** di samping input yang memicu pencarian ke API (juga bisa Enter)
- Tombol **Scan** tetap tersedia bersamaan dengan tombol Search selama buku belum ditemukan
- Setelah scan barcode berhasil, input langsung terisi dan API langsung dipanggil otomatis
- Hapus tab "Cari" dari modal `BarcodeScanner` — modal hanya menampilkan kamera scanner
- Sederhanakan modal: judul diubah ke "Scan Barcode", hapus state `activeTab`, `tabItems`, `manualCode`, `submitManual`

## File yang Diubah

| File | Perubahan |
|---|---|
| `app/pages/book/pinjam.vue` | Input tidak disabled, tambah tombol Search, refactor `onScanned` → `lookupBySerial` |
| `app/components/book/BarcodeScanner.vue` | Hapus tab "Cari", sederhanakan modal menjadi hanya kamera |

## Test plan

- [ ] Ketik serial number manual → klik tombol Search → buku ditemukan dan field terisi
- [ ] Ketik serial number manual → tekan Enter → buku ditemukan dan field terisi
- [ ] Klik tombol Scan → scan barcode → modal tutup otomatis → input terisi → API langsung dipanggil
- [ ] Jika kode tidak ditemukan → tampil toast error, input tidak direset
- [ ] Tombol Reset (X merah) muncul setelah buku ditemukan dan berhasil mereset form
- [ ] Modal scanner tidak lagi menampilkan tab "Cari"

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)