### PR TITLE
refactor(feedback): update feedback schema and translate to english

### DIFF
--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -6,6 +6,7 @@ import { useFeedback } from '~/composables/useFeedback'
 const props = defineProps<{
   open: boolean
   formState: {
+    url: string
     type: string
     description: string
     images: File[]
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 }>()
 
 const schema = z.object({
+  url: z.string().min(1, 'Url is required'),
   type: z.enum(['keluhan', 'saran', 'pujian']),
   description: z.string().min(1, 'Description is required'),
   images: z.array(z.instanceof(File)).min(1, 'At least 1 image is required').max(3, 'Maximum 3 images allowed')
@@ -26,6 +28,7 @@ const schema = z.object({
 type Schema = z.infer<typeof schema>
 
 const state = reactive<Schema>({
+  url: props.formState.url,
   type: ['keluhan', 'saran', 'pujian'].includes(props.formState.type)
     ? (props.formState.type as 'keluhan' | 'saran' | 'pujian')
     : 'keluhan',
@@ -34,6 +37,7 @@ const state = reactive<Schema>({
 })
 
 watch(() => props.formState, (v) => {
+  state.url = window.location.href
   state.type = ['keluhan', 'saran', 'pujian'].includes(v.type) ? (v.type as 'keluhan' | 'saran' | 'pujian') : 'keluhan'
   state.description = v.description
   state.images = v.images
@@ -41,9 +45,9 @@ watch(() => props.formState, (v) => {
 
 const saving = ref(false)
 const items = [
-  { label: 'Keluhan', value: 'keluhan' },
-  { label: 'Saran', value: 'saran' },
-  { label: 'Pujian', value: 'pujian' }
+  { label: 'Issue', value: 'keluhan' },
+  { label: 'Suggestion', value: 'saran' },
+  { label: 'Compliment', value: 'pujian' }
 ]
 
 const { createFeedback } = useFeedback()
@@ -74,6 +78,10 @@ async function onSubmit(_event: FormSubmitEvent<Schema>) {
       @update:open="emit('update:open', $event)"
     >
       <template #body>
+        <div class="mb-4">
+          <p>We are improving the information system so it works well for everyone. Thank you for your feedback.</p>
+          <span class="text-blue-500 font-medium underline">{{ state.url }}</span>
+        </div>
         <UForm
           :schema="schema"
           :state="state"

--- a/app/composables/useFeedback.ts
+++ b/app/composables/useFeedback.ts
@@ -1,6 +1,7 @@
 import { feedbackService } from '~/services/FeedbackService'
 import type {
   Feedback,
+  FeedbackRaw,
   CreateFeedbackPayload,
   FeedbackDetailResponse,
   Pagination,
@@ -39,7 +40,16 @@ export const useFeedback = (): FeedbackState => {
     error.value = null
     try {
       const res = await feedbackService.getFeedbacks(search, page, limit, byUser)
-      feedbacks.value = res.data
+      feedbacks.value = res.data.map((raw: FeedbackRaw): Feedback => ({
+        type: raw.category,
+        description: raw.message,
+        createdAt: raw.timestamp,
+        imageUrls: raw.imageUrls,
+        reply: raw.reply,
+        status: raw.status,
+        email: raw.email,
+        url: raw.url
+      }))
       apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {
       const fetchError = err as FetchError<ApiError>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -10,6 +10,7 @@ const isFeedbackLoading = ref(false)
 const scanModal = ref()
 
 const feedbackState = reactive({
+  url: '',
   type: 'keluhan',
   description: '',
   images: [] as File[]
@@ -83,6 +84,7 @@ const links = computed<NavigationMenuItem[][]>(() => [[
         const blob = await res.blob()
         const screenshotFile = new File([blob], `screenshot-${Date.now()}.png`, { type: 'image/png' })
         feedbackState.images = [screenshotFile]
+        feedbackState.url = window.location.href
         isFeedbackOpen.value = true
       } finally {
         isFeedbackLoading.value = false

--- a/app/pages/asset/[id]/detail.vue
+++ b/app/pages/asset/[id]/detail.vue
@@ -151,7 +151,7 @@ const statusColumns: TableColumn<any>[] = [
         'sold': 'warning',
         'granted': 'primary'
       }
-      return h(UBadge, { class: 'capitalize', variant: 'subtle', color: colorMap[type] || 'neutral', size: 'xs' }, () => type.replace('_', ' '))
+      return h(UBadge, { class: 'capitalize', variant: 'subtle', color: colorMap[type] || 'neutral', size: 'sm' }, () => type.replace('_', ' '))
     }
   },
   { 

--- a/app/pages/my-feedback.vue
+++ b/app/pages/my-feedback.vue
@@ -157,10 +157,6 @@ const columns = [
                         {{ row.original.reply }}
                       </p>
                     </div>
-                    <div class="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-                      <UIcon name="i-lucide-clock" class="w-3.5 h-3.5" />
-                      <span>Updated: {{ new Date(row.original.updatedAt).toLocaleString() }}</span>
-                    </div>
                   </div>
                   <div v-else class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-yellow-50 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-400 rounded-md text-sm">
                     <UIcon name="i-lucide-alert-circle" class="w-4 h-4" />

--- a/app/services/FeedbackService.ts
+++ b/app/services/FeedbackService.ts
@@ -56,6 +56,7 @@ export class FeedbackService {
 
   async createFeedback(payload: CreateFeedbackPayload): Promise<Feedback> {
     const formData = new FormData()
+    formData.append('url', payload.url)
     formData.append('type', payload.type)
     formData.append('description', payload.description)
     payload.images?.forEach(file => formData.append('images', file))

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -7,34 +7,48 @@ export const FeedbackTypeColor: Record<FeedbackType, string> = {
 }
 
 export type FeedbackStatus
-  = | 'new'
-    | 'ignored'
-    | 'noted'
-    | 'need discussion'
-    | 'accepted'
-    | 'in progress'
-    | 'done'
+  = | 'New'
+    | 'Ignored'
+    | 'Noted'
+    | 'Need Discussion'
+    | 'Accepted'
+    | 'In Progress'
+    | 'Done'
 
 export const FeedbackStatusColor: Record<FeedbackStatus, string> = {
-  'new': 'primary',
-  'ignored': 'neutral',
-  'noted': 'warning',
-  'need discussion': 'secondary',
-  'accepted': 'success',
-  'in progress': 'info',
-  'done': 'success'
+  'New': 'primary',
+  'Ignored': 'neutral',
+  'Noted': 'warning',
+  'Need Discussion': 'secondary',
+  'Accepted': 'success',
+  'In Progress': 'info',
+  'Done': 'success'
 }
 
 export interface Feedback {
-  id: string
+  id?: string
   type: FeedbackType
   description: string
   imageUrls?: string[]
   createdAt: string
-  updatedAt: string
+  updatedAt?: string
   reply?: string
   status?: FeedbackStatus
-  user: any
+  email?: string
+  url?: string
+}
+
+/** Raw shape returned by the API before mapping */
+export interface FeedbackRaw {
+  timestamp: string
+  email: string
+  image?: string[]
+  imageUrls?: string[]
+  url: string
+  category: FeedbackType
+  message: string
+  status: FeedbackStatus
+  reply: string
 }
 
 export interface FeedbackDetailResponse {
@@ -42,20 +56,22 @@ export interface FeedbackDetailResponse {
 }
 
 export interface FeedbackResponse {
-  data: Feedback[]
+  data: FeedbackRaw[]
   meta?: {
     pagination: Pagination
   }
 }
 
 export interface Pagination {
-  page: number
-  pageSize: number
-  total: number
-  pageCount: number
+  totalItems: number
+  itemCount: number
+  itemsPerPage: number
+  totalPages: number
+  currentPage: number
 }
 
 export interface CreateFeedbackPayload {
+  url: string
   type: FeedbackType
   description: string
   images?: File[]


### PR DESCRIPTION
Frontend:
- Update FeedbackModal to include URL field and translate messages to English
- Refactor feedback type labels (Keluhan -> Issue, Saran -> Suggestion, Pujian -> Compliment)
- Automatically capture and send current URL in feedback submission
- Remove updatedAt display in my-feedback page

Backend:
- Rename 'user' field to 'email' in Feedback service and DTOs
- Add 'imageUrls' and 'status' fields to Feedback response DTO
- Refactor feedback pagination to use consistent Pagination class
- Update filtering logic to use email instead of username