### PR TITLE
refactor: clean architecture - types, services, composables, components (#72)

### DIFF
--- a/app/components/asset/holder/AssignedModal.vue
+++ b/app/components/asset/holder/AssignedModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import * as z from 'zod'
-import { CalendarDate } from '@internationalized/date'
 import { useAssetHolder } from '~/composables/useAssetHolder'
 import { useEmployee } from '~/composables/useEmployee'
+import { assignHolderSchema, type AssignHolderSchema } from '~/schemas/holderSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{
   assetId: string
@@ -10,14 +10,8 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{ (e: 'created'): void }>()
 
-// Validation schema
-const schema = z.object({
-  assignedAt: z.string().min(1, 'Assigned date is required'),
-  employeeId: z.string().min(1, 'Employee is required'),
-  purpose: z.string().min(1, 'Purpose is required'),
-  attachments: z.array(z.custom<File>((val) => val instanceof File, 'Must be a File')).optional()
-})
-type Schema = z.output<typeof schema>
+const schema = assignHolderSchema
+type Schema = AssignHolderSchema
 
 const open = ref(false)
 const saving = ref(false)
@@ -31,29 +25,8 @@ const state = reactive({
 
 const assignedDateModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(assignedDateModel, (newDate) => {
-  if (newDate) {
-    state.assignedAt = calendarDateToString(newDate)
-  } else {
-    state.assignedAt = ''
-  }
+  state.assignedAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const { assignHolder } = useAssetHolder()
@@ -123,7 +96,7 @@ async function openModal() {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="assignedDateModel ? formatDateDisplay(assignedDateModel) : 'Select a date'"
+              :label="formatCalendarDate(assignedDateModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/asset/holder/ReturnedModal.vue
+++ b/app/components/asset/holder/ReturnedModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
-import { CalendarDate } from '@internationalized/date'
 import { useAssetHolder } from '~/composables/useAssetHolder'
+import { returnHolderSchema, type ReturnHolderSchema } from '~/schemas/holderSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{
   assetId: string
@@ -11,13 +11,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{ (e: 'returned'): void }>()
 
-// validation schema
-const schema = z.object({
-  returnedAt: z.string().min(1, 'Returned date is required'),
-  attachments: z.array(z.custom<File>((val) => val instanceof File, 'Must be a File')).optional()
-})
-
-type Schema = z.output<typeof schema>
+const schema = returnHolderSchema
+type Schema = ReturnHolderSchema
 
 const open = ref(false)
 const saving = ref(false)
@@ -29,29 +24,8 @@ const state = reactive<Partial<Schema>>({
 
 const returnedDateModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(returnedDateModel, (newDate) => {
-  if (newDate) {
-    state.returnedAt = calendarDateToString(newDate)
-  } else {
-    state.returnedAt = ''
-  }
+  state.returnedAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const { returnHolder } = useAssetHolder()
@@ -101,7 +75,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="returnedDateModel ? formatDateDisplay(returnedDateModel) : 'Select a date'"
+              :label="formatCalendarDate(returnedDateModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/asset/maintenance/AddModal.vue
+++ b/app/components/asset/maintenance/AddModal.vue
@@ -1,19 +1,14 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
-import { CalendarDate } from '@internationalized/date'
 import { useAssetMaintenance } from '~/composables/useAssetMaintenance'
+import { maintenanceSchema, type MaintenanceSchema } from '~/schemas/maintenanceSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{ assetId: string }>()
 const emit = defineEmits<{ (e: 'created'): void }>()
 
-// Schema validasi
-const schema = z.object({
-  maintenanceAt: z.string().min(1, 'Date is required'),
-  note: z.string().min(1, 'Note is required')
-})
-
-type Schema = z.output<typeof schema>
+const schema = maintenanceSchema
+type Schema = MaintenanceSchema
 
 const open = ref(false)
 const saving = ref(false)
@@ -25,29 +20,8 @@ const state = reactive<Partial<Schema>>({
 
 const maintenanceDateModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(maintenanceDateModel, (newDate) => {
-  if (newDate) {
-    state.maintenanceAt = calendarDateToString(newDate)
-  } else {
-    state.maintenanceAt = ''
-  }
+  state.maintenanceAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const { createMaintenance } = useAssetMaintenance()
@@ -86,7 +60,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="maintenanceDateModel ? formatDateDisplay(maintenanceDateModel) : 'Select a date'"
+              :label="formatCalendarDate(maintenanceDateModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/asset/maintenance/UpdateModal.vue
+++ b/app/components/asset/maintenance/UpdateModal.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { CalendarDate } from '@internationalized/date'
 import { useAssetMaintenance } from '~/composables/useAssetMaintenance'
+import { maintenanceSchema, type MaintenanceSchema } from '~/schemas/maintenanceSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{
   assetId: string
@@ -15,12 +16,8 @@ const emit = defineEmits<{
   (e: 'update:open', value: boolean): void
 }>()
 
-// Validasi schema
-const schema = z.object({
-  maintenanceAt: z.string().min(1, 'Date is required'),
-  note: z.string().min(1, 'Note is required')
-})
-type Schema = z.output<typeof schema>
+const schema = maintenanceSchema
+type Schema = MaintenanceSchema
 
 const formData = reactive<Schema>({
   maintenanceAt: '',
@@ -29,29 +26,8 @@ const formData = reactive<Schema>({
 
 const maintenanceDateModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(maintenanceDateModel, (newDate) => {
-  if (newDate) {
-    formData.maintenanceAt = calendarDateToString(newDate)
-  } else {
-    formData.maintenanceAt = ''
-  }
+  formData.maintenanceAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const saving = ref(false)
@@ -144,7 +120,7 @@ async function onSubmit(_event: FormSubmitEvent<Schema>) {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="maintenanceDateModel ? formatDateDisplay(maintenanceDateModel) : 'Select a date'"
+              :label="formatCalendarDate(maintenanceDateModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/asset/note/AddModal.vue
+++ b/app/components/asset/note/AddModal.vue
@@ -1,19 +1,14 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
-import { CalendarDate } from '@internationalized/date'
 import { useAssetNote } from '~/composables/useAssetNote'
+import { noteSchema, type NoteSchema } from '~/schemas/noteSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{ assetId: string }>()
 const emit = defineEmits<{ (e: 'created'): void }>()
 
-// Schema validasi
-const schema = z.object({
-occuredAt: z.string().min(1, 'Date is required'),
-  note: z.string().min(1, 'Note is required')
-})
-
-type Schema = z.output<typeof schema>
+const schema = noteSchema
+type Schema = NoteSchema
 
 const open = ref(false)
 const saving = ref(false)
@@ -25,29 +20,8 @@ const state = reactive<Partial<Schema>>({
 
 const occuredAtModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(occuredAtModel, (newDate) => {
-  if (newDate) {
-    state.occuredAt = calendarDateToString(newDate)
-  } else {
-    state.occuredAt = ''
-  }
+  state.occuredAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const { createNote } = useAssetNote()
@@ -86,7 +60,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="occuredAtModel ? formatDateDisplay(occuredAtModel) : 'Select a date'"
+              :label="formatCalendarDate(occuredAtModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/asset/note/UpdateModal.vue
+++ b/app/components/asset/note/UpdateModal.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { CalendarDate } from '@internationalized/date'
 import { useAssetNote } from '~/composables/useAssetNote'
+import { noteSchema, type NoteSchema } from '~/schemas/noteSchema'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{
   assetId: string
@@ -15,12 +16,8 @@ const emit = defineEmits<{
   (e: 'update:open', value: boolean): void
 }>()
 
-// Validasi schema
-const schema = z.object({
-  occuredAt: z.string().min(1, 'Date is required'),
-  note: z.string().min(1, 'Note is required')
-})
-type Schema = z.output<typeof schema>
+const schema = noteSchema
+type Schema = NoteSchema
 
 const formData = reactive<Schema>({
   occuredAt: '',
@@ -29,29 +26,8 @@ const formData = reactive<Schema>({
 
 const occuredAtModel = ref<any>(null)
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(occuredAtModel, (newDate) => {
-  if (newDate) {
-    formData.occuredAt = calendarDateToString(newDate)
-  } else {
-    formData.occuredAt = ''
-  }
+  formData.occuredAt = newDate ? calendarDateToISOString(newDate) : ''
 })
 
 const saving = ref(false)
@@ -144,7 +120,7 @@ async function onSubmit(_event: FormSubmitEvent<Schema>) {
           <UPopover :popper="{ placement: 'bottom-start' }">
             <UButton
               icon="i-lucide-calendar"
-              :label="occuredAtModel ? formatDateDisplay(occuredAtModel) : 'Select a date'"
+              :label="formatCalendarDate(occuredAtModel)"
               variant="subtle"
               color="neutral"
               class="w-full justify-start"

--- a/app/components/home/HomeStats.vue
+++ b/app/components/home/HomeStats.vue
@@ -1,21 +1,10 @@
 <script setup lang="ts">
 import { useStatistic } from '~/composables/useStatistic'
+import { formatCurrency, formatNumber } from '~/utils/formatters'
 
 const { count, loading, getCount } = useStatistic()
 
 await getCount()
-
-function formatNumber(value: number): string {
-  return value.toLocaleString('en-US')
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('id-ID', {
-    style: 'currency',
-    currency: 'IDR',
-    maximumFractionDigits: 0
-  }).format(value)
-}
 
 const stats = computed(() => {
   if (!count.value) return []

--- a/app/composables/useAsset.ts
+++ b/app/composables/useAsset.ts
@@ -6,8 +6,7 @@ import type {
   Pagination,
   AssetDetailResponse
 } from '~/types/asset'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AssetState {
   assets: Ref<Asset[]>
@@ -59,7 +58,7 @@ interface AssetState {
   }) => Promise<void>
 }
 
-export const useAsset = (): AssetState => {
+export function useAsset(): AssetState {
   const assets = ref<Asset[]>([])
   const selectedAsset = ref<Asset | null>(null)
   const apiPagination = ref<Pagination | null>(null)
@@ -92,51 +91,30 @@ export const useAsset = (): AssetState => {
     loading.value = true
     error.value = null
     try {
-      const {
-        search = searchTerm.value,
-        page = pagination.value.pageIndex + 1,
-        limit = pagination.value.pageSize,
-        user = null,
-        categoryId = null,
-        subCategoryId = null,
-        status = null,
-        employeeId = null,
-        locationId = null,
-        branchId = null,
-        startDate = null,
-        endDate = null,
-        hasHolder = null,
-        isLendable = null,
-        labels = null,
-        sort = null,
-        order = null
-      } = options || {}
-
-      const res = await assetService.getAssets(
-        search,
-        page,
-        limit,
-        user,
-        categoryId,
-        subCategoryId,
-        status,
-        employeeId,
-        locationId,
-        branchId,
-        startDate,
-        endDate,
-        hasHolder,
-        isLendable,
-        labels,
-        sort,
-        order
-      )
+      const res = await assetService.getAssets({
+        search: options?.search ?? searchTerm.value,
+        page: options?.page ?? pagination.value.pageIndex + 1,
+        limit: options?.limit ?? pagination.value.pageSize,
+        user: options?.user ?? null,
+        categoryId: options?.categoryId ?? null,
+        subCategoryId: options?.subCategoryId ?? null,
+        status: options?.status ?? null,
+        employeeId: options?.employeeId ?? null,
+        locationId: options?.locationId ?? null,
+        branchId: options?.branchId ?? null,
+        startDate: options?.startDate ?? null,
+        endDate: options?.endDate ?? null,
+        hasHolder: options?.hasHolder ?? null,
+        isLendable: options?.isLendable ?? null,
+        labels: options?.labels ?? null,
+        sort: options?.sort ?? null,
+        order: options?.order ?? null
+      })
 
       assets.value = res.data
       apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch assets'
+      error.value = extractErrorMessage(err, 'Failed to fetch assets')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -156,8 +134,7 @@ export const useAsset = (): AssetState => {
       selectedAsset.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch asset detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch asset detail')
       toast.add({ title: 'Failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -172,8 +149,7 @@ export const useAsset = (): AssetState => {
       const res = await assetService.getAssetLogs(id)
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch asset logs'
+      error.value = extractErrorMessage(err, 'Failed to fetch asset logs')
       toast.add({ title: 'Failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -191,8 +167,7 @@ export const useAsset = (): AssetState => {
       return res
     } catch (err: unknown) {
       if (!silent) {
-        const fetchError = err as FetchError<ApiError>
-        error.value = fetchError.data?.message ?? 'Failed to fetch asset detail'
+        error.value = extractErrorMessage(err, 'Failed to fetch asset detail')
         toast.add({ title: 'Failed', description: error.value, color: 'error' })
       }
       return null
@@ -208,8 +183,7 @@ export const useAsset = (): AssetState => {
       const res = await assetService.getAssetByImage(image)
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to identify asset from image'
+      error.value = extractErrorMessage(err, 'Failed to identify asset from image')
       toast.add({ title: 'AI Scan Failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -226,8 +200,7 @@ export const useAsset = (): AssetState => {
       await refreshAssets()
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create asset'
+      error.value = extractErrorMessage(err, 'Failed to create asset')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -244,8 +217,7 @@ export const useAsset = (): AssetState => {
       await refreshAssets()
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create asset'
+      error.value = extractErrorMessage(err, 'Failed to create asset')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -261,8 +233,7 @@ export const useAsset = (): AssetState => {
       toast.add({ title: 'Updated', description: 'Asset updated successfully', color: 'success' })
       await refreshAssets()
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update asset'
+      error.value = extractErrorMessage(err, 'Failed to update asset')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -278,8 +249,7 @@ export const useAsset = (): AssetState => {
       toast.add({ title: 'Deleted', description: 'Asset deleted successfully', color: 'success' })
       await refreshAssets()
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete asset'
+      error.value = extractErrorMessage(err, 'Failed to delete asset')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -294,8 +264,7 @@ export const useAsset = (): AssetState => {
       const res = await assetService.getLabels(search)
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch labels'
+      error.value = extractErrorMessage(err, 'Failed to fetch labels')
       toast.add({ title: 'Failed', description: error.value, color: 'error' })
       return []
     } finally {
@@ -319,19 +288,7 @@ export const useAsset = (): AssetState => {
     loading.value = true
     error.value = null
     try {
-      const { blob, filename } = await assetService.exportAssets(
-        filters.user || null,
-        filters.categoryId || null,
-        filters.subCategoryId || null,
-        filters.status || null,
-        filters.employeeId || null,
-        filters.locationId || null,
-        filters.branchId || null,
-        filters.startDate || null,
-        filters.endDate || null,
-        filters.isLendable !== undefined ? filters.isLendable : null,
-        filters.labels || null
-      )
+      const { blob, filename } = await assetService.exportAssets(filters)
 
       const url = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
@@ -350,9 +307,7 @@ export const useAsset = (): AssetState => {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      console.log(fetchError)
-      error.value = fetchError.data?.message ?? 'Failed to export assets'
+      error.value = extractErrorMessage(err, 'Failed to export assets')
       toast.add({
         title: 'Export failed',
         description: error.value,

--- a/app/composables/useAssetHolder.ts
+++ b/app/composables/useAssetHolder.ts
@@ -7,8 +7,7 @@ import type {
   AssetHolderDetailResponse,
   Pagination
 } from '~/types/assetHolder'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AssetHolderState {
   holders: Ref<AssetHolder[]>
@@ -80,8 +79,7 @@ export function useAssetHolder(): AssetHolderState {
         total: res.meta?.pagination?.totalItems ?? 0
       }
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch holders'
+      error.value = extractErrorMessage(err, 'Failed to fetch holders')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -109,8 +107,7 @@ export function useAssetHolder(): AssetHolderState {
       selectedHolder.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch holder detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch holder detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -133,8 +130,7 @@ export function useAssetHolder(): AssetHolderState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to assign holder'
+      error.value = extractErrorMessage(err, 'Failed to assign holder')
       toast.add({ title: 'Assign failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -158,8 +154,7 @@ export function useAssetHolder(): AssetHolderState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to return holder'
+      error.value = extractErrorMessage(err, 'Failed to return holder')
       toast.add({ title: 'Return failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -184,8 +179,7 @@ export function useAssetHolder(): AssetHolderState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to request asset'
+      error.value = extractErrorMessage(err, 'Failed to request asset')
       toast.add({ title: 'Request failed', description: error.value, color: 'error' })
       throw err
     } finally {

--- a/app/composables/useAssetLocation.ts
+++ b/app/composables/useAssetLocation.ts
@@ -6,8 +6,7 @@ import type {
   CreateAssetLocationPayload,
   Pagination
 } from '~/types/assetLocation'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AssetLocationState {
   locations: Ref<AssetLocation[]>
@@ -61,8 +60,7 @@ export function useAssetLocation(): AssetLocationState {
         total: res.meta?.pagination?.totalItems ?? 0
       }
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch locations'
+      error.value = extractErrorMessage(err, 'Failed to fetch locations')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -93,8 +91,7 @@ export function useAssetLocation(): AssetLocationState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create location'
+      error.value = extractErrorMessage(err, 'Failed to create location')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {

--- a/app/composables/useAssetMaintenance.ts
+++ b/app/composables/useAssetMaintenance.ts
@@ -6,8 +6,7 @@ import type {
   AssetMaintenanceDetailResponse,
   Pagination
 } from '~/types/assetMaintenance'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AssetMaintenanceState {
   maintenances: Ref<AssetMaintenance[]>
@@ -73,8 +72,7 @@ export function useAssetMaintenance(): AssetMaintenanceState {
         total: res.meta?.pagination?.totalItems ?? 0
       }
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch maintenances'
+      error.value = extractErrorMessage(err, 'Failed to fetch maintenances')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -105,8 +103,7 @@ export function useAssetMaintenance(): AssetMaintenanceState {
       selectedMaintenance.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch maintenance detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch maintenance detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -129,8 +126,7 @@ export function useAssetMaintenance(): AssetMaintenanceState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create maintenance'
+      error.value = extractErrorMessage(err, 'Failed to create maintenance')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -154,8 +150,7 @@ export function useAssetMaintenance(): AssetMaintenanceState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update maintenance'
+      error.value = extractErrorMessage(err, 'Failed to update maintenance')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -177,8 +172,7 @@ export function useAssetMaintenance(): AssetMaintenanceState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete maintenance'
+      error.value = extractErrorMessage(err, 'Failed to delete maintenance')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useAssetNote.ts
+++ b/app/composables/useAssetNote.ts
@@ -6,8 +6,7 @@ import type {
   AssetNoteDetailResponse,
   Pagination
 } from '~/types/assetNote'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AssetNoteState {
   notes: Ref<AssetNote[]>
@@ -73,8 +72,7 @@ export function useAssetNote(): AssetNoteState {
         total: res.meta?.pagination?.totalItems ?? 0
       }
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch maintenances'
+      error.value = extractErrorMessage(err, 'Failed to fetch notes')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -105,8 +103,7 @@ export function useAssetNote(): AssetNoteState {
       selectedNote.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch note detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch note detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -129,8 +126,7 @@ export function useAssetNote(): AssetNoteState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create maintenance'
+      error.value = extractErrorMessage(err, 'Failed to create note')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -154,8 +150,7 @@ export function useAssetNote(): AssetNoteState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update maintenance'
+      error.value = extractErrorMessage(err, 'Failed to update note')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -177,8 +172,7 @@ export function useAssetNote(): AssetNoteState {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete maintenance'
+      error.value = extractErrorMessage(err, 'Failed to delete note')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useAssetStatus.ts
+++ b/app/composables/useAssetStatus.ts
@@ -1,8 +1,7 @@
 import { assetStatusService, type CreateAssetStatusPayload, type AssetStatusResponse } from '~/services/AssetStatusService'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
-export const useAssetStatus = () => {
+export function useAssetStatus() {
   const statuses = ref<AssetStatusResponse[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -20,8 +19,7 @@ export const useAssetStatus = () => {
       })
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update status'
+      error.value = extractErrorMessage(err, 'Failed to update status')
       toast.add({
         title: 'Update Failed',
         description: error.value,
@@ -41,8 +39,7 @@ export const useAssetStatus = () => {
       statuses.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch statuses'
+      error.value = extractErrorMessage(err, 'Failed to fetch statuses')
       toast.add({
         title: 'Fetch Failed',
         description: error.value,

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -1,8 +1,7 @@
 import type { Ref, ComputedRef } from 'vue'
 import type { User } from '~/types/auth'
-import type { ApiError } from '~/types/api'
 import { authService } from '~/services/AuthServices'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface AuthState {
   accessToken: Ref<string | null>
@@ -16,7 +15,7 @@ interface AuthState {
   getMe: () => Promise<boolean>
 }
 
-export const useAuth = (): AuthState => {
+export function useAuth(): AuthState {
   const router = useRouter()
   const toast = useToast()
 
@@ -74,10 +73,9 @@ export const useAuth = (): AuthState => {
       toast.add({ title: 'Success', description: 'Logged in successfully' })
       return true
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
       toast.add({
         title: 'Login failed',
-        description: fetchError.data?.message || 'Something went wrong',
+        description: extractErrorMessage(err, 'Something went wrong'),
         color: 'error'
       })
       return false
@@ -92,10 +90,9 @@ export const useAuth = (): AuthState => {
       toast.add({ title: 'Success', description: 'Logged in successfully' })
       return true
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
       toast.add({
         title: 'Login failed',
-        description: fetchError.data?.message || 'Something went wrong',
+        description: extractErrorMessage(err, 'Something went wrong'),
         color: 'error'
       })
       return false
@@ -119,10 +116,9 @@ export const useAuth = (): AuthState => {
       await getMe()
       return true
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
       toast.add({
         title: 'Session expired',
-        description: fetchError.data?.message || 'Please login again',
+        description: extractErrorMessage(err, 'Please login again'),
         color: 'error'
       })
       clearTokens()
@@ -140,10 +136,9 @@ export const useAuth = (): AuthState => {
       }
       return true
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
       toast.add({
         title: 'Failed to fetch user',
-        description: fetchError.data?.message || 'Something went wrong',
+        description: extractErrorMessage(err, 'Something went wrong'),
         color: 'error'
       })
       clearTokens()

--- a/app/composables/useBranch.ts
+++ b/app/composables/useBranch.ts
@@ -1,8 +1,7 @@
 // ~/composables/useBranch.ts
 import { branchService } from '~/services/BranchService'
 import type { Branch } from '~/types/branch'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface BranchState {
   branches: Ref<Branch[]>
@@ -12,7 +11,7 @@ interface BranchState {
   refreshBranches: () => Promise<void>
 }
 
-export const useBranch = (): BranchState => {
+export function useBranch(): BranchState {
   const branches = ref<Branch[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -25,8 +24,7 @@ export const useBranch = (): BranchState => {
       const res = await branchService.getAllBranches(search)
       branches.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch branches'
+      error.value = extractErrorMessage(err, 'Failed to fetch branches')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useCategory.ts
+++ b/app/composables/useCategory.ts
@@ -1,9 +1,7 @@
 import { categoryService } from '~/services/CategoryService'
 import type { Category, CreateCategoryPayload, UpdateCategoryPayload, Pagination, CategoryDetailResponse } from '~/types/category'
 import type { SubCategory } from '~/types/subCategory'
-
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface CategoryState {
   categories: Ref<Category[]>
@@ -23,7 +21,7 @@ interface CategoryState {
   getAllCategories: () => Promise<void>
 }
 
-export const useCategory = (): CategoryState => {
+export function useCategory(): CategoryState {
   const categories = ref<Category[]>([])
   const selectedCategory = ref<Category | null>(null)
   const subCategories = ref<SubCategory[]>([])
@@ -41,8 +39,7 @@ export const useCategory = (): CategoryState => {
       const res = await categoryService.getAllCategories(true)
       categories.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch categories'
+      error.value = extractErrorMessage(err, 'Failed to fetch categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -57,8 +54,7 @@ export const useCategory = (): CategoryState => {
       categories.value = res.data
       apiPagination.value = res.meta.pagination
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch categories'
+      error.value = extractErrorMessage(err, 'Failed to fetch categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -78,8 +74,7 @@ export const useCategory = (): CategoryState => {
       toast.add({ title: 'Created', description: 'Category created successfully', color: 'success' })
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create category'
+      error.value = extractErrorMessage(err, 'Failed to create category')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -95,8 +90,7 @@ export const useCategory = (): CategoryState => {
       selectedCategory.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch category detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch category detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -111,8 +105,7 @@ export const useCategory = (): CategoryState => {
       const res = await categoryService.getSubCategoriesByCategory(id)
       subCategories.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch sub-categories'
+      error.value = extractErrorMessage(err, 'Failed to fetch sub-categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -127,8 +120,7 @@ export const useCategory = (): CategoryState => {
       await refreshCategories()
       toast.add({ title: 'Updated', description: 'Category updated successfully', color: 'success' })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update category'
+      error.value = extractErrorMessage(err, 'Failed to update category')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -143,8 +135,7 @@ export const useCategory = (): CategoryState => {
       await refreshCategories()
       toast.add({ title: 'Deleted', description: 'Category deleted successfully', color: 'success' })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete category'
+      error.value = extractErrorMessage(err, 'Failed to delete category')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useEmployee.ts
+++ b/app/composables/useEmployee.ts
@@ -1,8 +1,7 @@
 // ~/composables/useEmployee.ts
 import { employeeService } from '~/services/EmployeeService'
 import type { Employee } from '~/types/employee'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface EmployeeState {
   employees: Ref<Employee[]>
@@ -12,7 +11,7 @@ interface EmployeeState {
   refreshEmployees: () => Promise<void>
 }
 
-export const useEmployee = (): EmployeeState => {
+export function useEmployee(): EmployeeState {
   const employees = ref<Employee[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -25,8 +24,7 @@ export const useEmployee = (): EmployeeState => {
       const res = await employeeService.getAllEmployees(search)
       employees.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch employees'
+      error.value = extractErrorMessage(err, 'Failed to fetch employees')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useFeedback.ts
+++ b/app/composables/useFeedback.ts
@@ -7,8 +7,7 @@ import type {
   Pagination,
   UpdateFeedbackPayload
 } from '~/types/feedback'
-import type { FetchError } from 'ofetch'
-import type { ApiError } from '~/types/api'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface FeedbackState {
   feedbacks: Ref<Feedback[]>
@@ -24,7 +23,7 @@ interface FeedbackState {
   updateFeedback: (id: string, payload: UpdateFeedbackPayload) => Promise<Feedback | undefined>
 }
 
-export const useFeedback = (): FeedbackState => {
+export function useFeedback(): FeedbackState {
   const feedbacks = ref<Feedback[]>([])
   const selectedFeedback = ref<Feedback | null>(null)
   const apiPagination = ref<Pagination | null>(null)
@@ -34,7 +33,6 @@ export const useFeedback = (): FeedbackState => {
 
   const pagination = ref({ pageIndex: 0, pageSize: 10 })
 
-  // 🟢 Tambahkan byUser (default: true)
   async function fetchFeedbacks(search = '', page = 1, limit = 10, byUser = true): Promise<void> {
     loading.value = true
     error.value = null
@@ -52,8 +50,7 @@ export const useFeedback = (): FeedbackState => {
       }))
       apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch feedbacks'
+      error.value = extractErrorMessage(err, 'Failed to fetch feedbacks')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -73,8 +70,7 @@ export const useFeedback = (): FeedbackState => {
       toast.add({ title: 'Created', description: 'Feedback created successfully', color: 'success' })
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create feedback'
+      error.value = extractErrorMessage(err, 'Failed to create feedback')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -90,8 +86,7 @@ export const useFeedback = (): FeedbackState => {
       selectedFeedback.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch feedback detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch feedback detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -108,8 +103,7 @@ export const useFeedback = (): FeedbackState => {
       toast.add({ title: 'Updated', description: 'Feedback updated successfully', color: 'success' })
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update feedback'
+      error.value = extractErrorMessage(err, 'Failed to update feedback')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useLocation.ts
+++ b/app/composables/useLocation.ts
@@ -1,7 +1,6 @@
 import { locationService } from '~/services/LocationService'
 import type { Location, CreateLocationPayload, UpdateLocationPayload, Pagination, LocationDetailResponse } from '~/types/location'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 import { ref, watch, type Ref } from 'vue'
 
 interface LocationState {
@@ -20,7 +19,7 @@ interface LocationState {
   getAllLocations: (branchId?: string) => Promise<void>
 }
 
-export const useLocation = (): LocationState => {
+export function useLocation(): LocationState {
   const locations = ref<Location[]>([])
   const selectedLocation = ref<Location | null>(null)
   const apiPagination = ref<Pagination | null>(null)
@@ -31,27 +30,21 @@ export const useLocation = (): LocationState => {
   const pagination = ref({ pageIndex: 0, pageSize: 10 })
   const searchTerm = ref('')
 
-  const handleError = (err: unknown, defaultMessage: string) => {
-    const fetchError = err as FetchError<ApiError>
-    const msg = fetchError?.data?.message ?? defaultMessage
-    error.value = msg
-    toast.add({ title: 'Error', description: msg, color: 'error' })
-  }
-
-  const getAllLocations = async (branchId = ''): Promise<void> => {
+  async function getAllLocations(branchId = ''): Promise<void> {
     loading.value = true
     error.value = null
     try {
       const res = await locationService.getAllLocations(true, branchId)
       locations.value = res.data
-    } catch (err) {
-      handleError(err, 'Failed to fetch locations')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to fetch locations')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  const fetchLocations = async (search = '', page = 1, limit = 10): Promise<void> => {
+  async function fetchLocations(search = '', page = 1, limit = 10): Promise<void> {
     loading.value = true
     error.value = null
     try {
@@ -59,18 +52,19 @@ export const useLocation = (): LocationState => {
       locations.value = res.data
       apiPagination.value = res.meta.pagination
       pagination.value.pageIndex = page - 1
-    } catch (err) {
-      handleError(err, 'Failed to fetch locations')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to fetch locations')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  const refreshLocations = async (): Promise<void> => {
+  async function refreshLocations(): Promise<void> {
     await fetchLocations(searchTerm.value, pagination.value.pageIndex + 1, pagination.value.pageSize)
   }
 
-  const createLocation = async (payload: CreateLocationPayload): Promise<LocationDetailResponse | null> => {
+  async function createLocation(payload: CreateLocationPayload): Promise<LocationDetailResponse | null> {
     loading.value = true
     error.value = null
     try {
@@ -78,15 +72,16 @@ export const useLocation = (): LocationState => {
       await refreshLocations()
       toast.add({ title: 'Created', description: 'Location created successfully', color: 'success' })
       return res
-    } catch (err) {
-      handleError(err, 'Failed to create location')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to create location')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
       return null
     } finally {
       loading.value = false
     }
   }
 
-  const getLocationById = async (id: string): Promise<LocationDetailResponse | null> => {
+  async function getLocationById(id: string): Promise<LocationDetailResponse | null> {
     loading.value = true
     error.value = null
     selectedLocation.value = null
@@ -94,43 +89,45 @@ export const useLocation = (): LocationState => {
       const res = await locationService.getLocationById(id)
       selectedLocation.value = res.data
       return res
-    } catch (err) {
-      handleError(err, 'Failed to fetch location detail')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to fetch location detail')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
       return null
     } finally {
       loading.value = false
     }
   }
 
-  const updateLocation = async (id: string, payload: UpdateLocationPayload): Promise<void> => {
+  async function updateLocation(id: string, payload: UpdateLocationPayload): Promise<void> {
     loading.value = true
     error.value = null
     try {
       await locationService.updateLocation(id, payload)
       await refreshLocations()
       toast.add({ title: 'Updated', description: 'Location updated successfully', color: 'success' })
-    } catch (err) {
-      handleError(err, 'Failed to update location')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to update location')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  const deleteLocation = async (id: string): Promise<void> => {
+  async function deleteLocation(id: string): Promise<void> {
     loading.value = true
     error.value = null
     try {
       await locationService.deleteLocation(id)
       await refreshLocations()
       toast.add({ title: 'Deleted', description: 'Location deleted successfully', color: 'success' })
-    } catch (err) {
-      handleError(err, 'Failed to delete location')
+    } catch (err: unknown) {
+      error.value = extractErrorMessage(err, 'Failed to delete location')
+      toast.add({ title: 'Error', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  // Watch searchTerm and fetch locations
   watch(searchTerm, () => {
     pagination.value.pageIndex = 0
     fetchLocations(searchTerm.value, 1, pagination.value.pageSize)

--- a/app/composables/useProperty.ts
+++ b/app/composables/useProperty.ts
@@ -5,8 +5,7 @@ import type {
   UpdatePropertyPayload,
   PropertyDetailResponse
 } from '~/types/property'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface PropertyState {
   properties: Ref<Property[]>
@@ -20,14 +19,13 @@ interface PropertyState {
   deleteProperty: (subCategoryId: string, propertyId: string) => Promise<void>
 }
 
-export const useProperty = (): PropertyState => {
+export function useProperty(): PropertyState {
   const properties = ref<Property[]>([])
   const selectedProperty = ref<Property | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
   const toast = useToast()
 
-  // Fetch all properties for a subcategory (no pagination)
   async function fetchProperties(subCategoryId: string): Promise<void> {
     loading.value = true
     error.value = null
@@ -35,15 +33,13 @@ export const useProperty = (): PropertyState => {
       const res = await propertyService.getAllProperties(subCategoryId, true)
       properties.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch properties'
+      error.value = extractErrorMessage(err, 'Failed to fetch properties')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  // Fetch detail by ID
   async function getPropertyById(subCategoryId: string, propertyId: string): Promise<PropertyDetailResponse | null> {
     loading.value = true
     error.value = null
@@ -53,8 +49,7 @@ export const useProperty = (): PropertyState => {
       selectedProperty.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch property detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch property detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -62,22 +57,19 @@ export const useProperty = (): PropertyState => {
     }
   }
 
-  // Create
   async function createProperty(subCategoryId: string, payload: CreatePropertyPayload): Promise<void> {
     loading.value = true
     error.value = null
     try {
       await propertyService.createProperty(subCategoryId, payload)
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create property'
+      error.value = extractErrorMessage(err, 'Failed to create property')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  // Update
   async function updateProperty(subCategoryId: string, propertyId: string, payload: UpdatePropertyPayload): Promise<void> {
     loading.value = true
     error.value = null
@@ -86,15 +78,13 @@ export const useProperty = (): PropertyState => {
       await fetchProperties(subCategoryId)
       toast.add({ title: 'Updated', description: 'Property updated successfully', color: 'success' })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update property'
+      error.value = extractErrorMessage(err, 'Failed to update property')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  // Delete
   async function deleteProperty(subCategoryId: string, propertyId: string): Promise<void> {
     loading.value = true
     error.value = null
@@ -103,8 +93,7 @@ export const useProperty = (): PropertyState => {
       await fetchProperties(subCategoryId)
       toast.add({ title: 'Deleted', description: 'Property deleted successfully', color: 'success' })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete property'
+      error.value = extractErrorMessage(err, 'Failed to delete property')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useRole.ts
+++ b/app/composables/useRole.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 import { useAuth } from './useAuth'
 
-export const useRole = () => {
+export function useRole() {
   const { user } = useAuth()
 
   const isAdmin = computed(() => user.value?.role === 'admin')

--- a/app/composables/useStatistic.ts
+++ b/app/composables/useStatistic.ts
@@ -7,10 +7,9 @@ import type {
   CategoryPriceResponse,
   LocationPriceResponse,
   AssetAgingResponse,
-  DataQualityResponse,
-  ApiResponse
+  DataQualityResponse
 } from '~/types/statistic'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 import { statisticService } from '~/services/StatisticService'
 
 export function useStatistic() {
@@ -34,8 +33,7 @@ export function useStatistic() {
       const res = await statisticService.getCount()
       count.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch count data'
+      error.value = extractErrorMessage(err, 'Failed to fetch count data')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -49,8 +47,7 @@ export function useStatistic() {
       const res = await statisticService.getAssetsByCategory()
       assetsByCategory.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch assets by category'
+      error.value = extractErrorMessage(err, 'Failed to fetch assets by category')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -64,8 +61,7 @@ export function useStatistic() {
       const res = await statisticService.getAssetsBySubCategory()
       assetsBySubCategory.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch assets by sub-category'
+      error.value = extractErrorMessage(err, 'Failed to fetch assets by sub-category')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -79,8 +75,7 @@ export function useStatistic() {
       const res = await statisticService.getAssetsByLocation()
       assetsByLocation.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch assets by location'
+      error.value = extractErrorMessage(err, 'Failed to fetch assets by location')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -94,8 +89,7 @@ export function useStatistic() {
       const res = await statisticService.getPriceByCategory()
       priceByCategory.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch price by category'
+      error.value = extractErrorMessage(err, 'Failed to fetch price by category')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -109,8 +103,7 @@ export function useStatistic() {
       const res = await statisticService.getPriceByLocation()
       priceByLocation.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch price by location'
+      error.value = extractErrorMessage(err, 'Failed to fetch price by location')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -124,8 +117,7 @@ export function useStatistic() {
       const res = await statisticService.getAssetAging()
       assetAging.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch asset aging'
+      error.value = extractErrorMessage(err, 'Failed to fetch asset aging')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -139,8 +131,7 @@ export function useStatistic() {
       const res = await statisticService.getDataQuality()
       dataQuality.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiResponse<unknown>>
-      error.value = fetchError.data?.message ?? 'Failed to fetch data quality'
+      error.value = extractErrorMessage(err, 'Failed to fetch data quality')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false

--- a/app/composables/useSubCategory.ts
+++ b/app/composables/useSubCategory.ts
@@ -8,8 +8,7 @@ import type {
   Pagination,
   SubCategoryDetailResponse
 } from '~/types/subCategory'
-import type { ApiError } from '~/types/api'
-import type { FetchError } from 'ofetch'
+import { extractErrorMessage } from '~/utils/errorHandler'
 
 interface SubCategoryState {
   subCategories: Ref<SubCategory[]>
@@ -33,7 +32,7 @@ interface SubCategoryState {
   getFlattenedTree: (tree: SubCategory[], level?: number) => Array<SubCategory & { indent: string }>
 }
 
-export const useSubCategory = (): SubCategoryState => {
+export function useSubCategory(): SubCategoryState {
   const subCategories = ref<SubCategory[]>([])
   const hierarchyTree = ref<SubCategory[]>([])
   const selectedSubCategory = ref<SubCategory | null>(null)
@@ -58,8 +57,7 @@ export const useSubCategory = (): SubCategoryState => {
       subCategories.value = res.data
       apiPagination.value = res.meta.pagination
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch sub-categories'
+      error.value = extractErrorMessage(err, 'Failed to fetch sub-categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -73,8 +71,7 @@ export const useSubCategory = (): SubCategoryState => {
       const res = await subCategoryService.getHierarchyTree(categoryUuid)
       hierarchyTree.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch hierarchy tree'
+      error.value = extractErrorMessage(err, 'Failed to fetch hierarchy tree')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -88,8 +85,7 @@ export const useSubCategory = (): SubCategoryState => {
       const res = await subCategoryService.getSubCategoriesByCategory(categoryUuid)
       subCategories.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch sub-categories'
+      error.value = extractErrorMessage(err, 'Failed to fetch sub-categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -113,8 +109,7 @@ export const useSubCategory = (): SubCategoryState => {
       await refreshSubCategories()
       return res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to create sub category'
+      error.value = extractErrorMessage(err, 'Failed to create sub category')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })
       throw err
     } finally {
@@ -131,8 +126,7 @@ export const useSubCategory = (): SubCategoryState => {
       selectedSubCategory.value = res.data
       return res
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch sub category detail'
+      error.value = extractErrorMessage(err, 'Failed to fetch sub category detail')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
       return null
     } finally {
@@ -147,8 +141,7 @@ export const useSubCategory = (): SubCategoryState => {
       const res = await subCategoryService.getSubCategoryPath(id)
       breadcrumbPath.value = res.data
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to fetch sub category path'
+      error.value = extractErrorMessage(err, 'Failed to fetch sub category path')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -167,8 +160,7 @@ export const useSubCategory = (): SubCategoryState => {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to update sub category'
+      error.value = extractErrorMessage(err, 'Failed to update sub category')
       toast.add({ title: 'Update failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
@@ -187,21 +179,18 @@ export const useSubCategory = (): SubCategoryState => {
         color: 'success'
       })
     } catch (err: unknown) {
-      const fetchError = err as FetchError<ApiError>
-      error.value = fetchError.data?.message ?? 'Failed to delete sub category'
+      error.value = extractErrorMessage(err, 'Failed to delete sub category')
       toast.add({ title: 'Delete failed', description: error.value, color: 'error' })
     } finally {
       loading.value = false
     }
   }
 
-  // Helper: Get available parents (exclude self and descendants)
   function getAvailableParents(categoryUuid: string, currentId?: string): SubCategory[] {
     if (!currentId) return subCategories.value
 
     const excludedIds = new Set<string>([currentId])
 
-    // Recursively collect all descendant IDs
     function collectDescendants(subCat: SubCategory) {
       if (subCat.children) {
         for (const child of subCat.children) {
@@ -219,7 +208,6 @@ export const useSubCategory = (): SubCategoryState => {
     return subCategories.value.filter(s => !excludedIds.has(s.id))
   }
 
-  // Helper: Flatten tree for dropdown display with indentation
   function getFlattenedTree(
     tree: SubCategory[],
     level = 0

--- a/app/composables/useUserAsset.ts
+++ b/app/composables/useUserAsset.ts
@@ -1,8 +1,8 @@
 import { userAssetService } from '~/services/UserAssetService'
 import type { UserAsset, UserAssetResponse } from '~/types/userAsset'
-import type { Pagination } from '~/types/assetHolder'
+import type { Pagination } from '~/types/api'
 
-export const useUserAsset = () => {
+export function useUserAsset() {
   const assets = ref<UserAsset[]>([])
   const loading = ref(false)
   const apiPagination = ref<Pagination | null>(null)
@@ -11,7 +11,7 @@ export const useUserAsset = () => {
     pageSize: 10
   })
 
-  const fetchActiveAssets = async (page = pagination.value.pageIndex + 1, limit = pagination.value.pageSize) => {
+  async function fetchActiveAssets(page = pagination.value.pageIndex + 1, limit = pagination.value.pageSize) {
     loading.value = true
     try {
       const res = await userAssetService.getActiveAssets(page, limit)
@@ -25,7 +25,7 @@ export const useUserAsset = () => {
     }
   }
 
-  const fetchHistoryAssets = async (page = pagination.value.pageIndex + 1, limit = pagination.value.pageSize) => {
+  async function fetchHistoryAssets(page = pagination.value.pageIndex + 1, limit = pagination.value.pageSize) {
     loading.value = true
     try {
       const res = await userAssetService.getHistoryAssets(page, limit)
@@ -39,7 +39,7 @@ export const useUserAsset = () => {
     }
   }
 
-  const returnAsset = async (assetUuid: string, uuid: string, payload: { image: File }) => {
+  async function returnAsset(assetUuid: string, uuid: string, payload: { image: File }) {
     loading.value = true
     try {
       await userAssetService.returnRequest(assetUuid, uuid, payload)

--- a/app/pages/asset/[id]/detail.vue
+++ b/app/pages/asset/[id]/detail.vue
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 import { useAssetHolder } from '~/composables/useAssetHolder'
 import { useAssetMaintenance } from '~/composables/useAssetMaintenance'
+import { formatCurrency } from '~/utils/formatters'
 
 const UAvatar = resolveComponent('UAvatar')
 const UBadge = resolveComponent('UBadge')
@@ -29,14 +30,6 @@ function openImageModal(url: string) {
 
 function closeImageModal() {
   previewImage.value = null
-}
-
-function IDRFormat(value: number) {
-  return new Intl.NumberFormat('id-ID', {
-    style: 'currency',
-    currency: 'IDR',
-    minimumFractionDigits: 0
-  }).format(Number(value))
 }
 
 async function loadHolders() {
@@ -403,7 +396,7 @@ async function loadLogs() {
                   <div>
                     <label class="text-sm font-medium text-gray-500 dark:text-gray-400">Price</label>
                     <p class="text-gray-900 dark:text-white font-medium text-sm">
-                      {{ IDRFormat(assetDetail.price) }}
+                      {{ formatCurrency(assetDetail.price) }}
                     </p>
                   </div>
 

--- a/app/schemas/holderSchema.ts
+++ b/app/schemas/holderSchema.ts
@@ -1,0 +1,16 @@
+import * as z from 'zod'
+
+export const assignHolderSchema = z.object({
+  assignedAt: z.string().min(1, 'Assigned date is required'),
+  employeeId: z.string().min(1, 'Employee is required'),
+  purpose: z.string().min(1, 'Purpose is required'),
+  attachments: z.array(z.custom<File>((val) => val instanceof File, 'Must be a File')).optional()
+})
+
+export const returnHolderSchema = z.object({
+  returnedAt: z.string().min(1, 'Returned date is required'),
+  attachments: z.array(z.custom<File>((val) => val instanceof File, 'Must be a File')).optional()
+})
+
+export type AssignHolderSchema = z.output<typeof assignHolderSchema>
+export type ReturnHolderSchema = z.output<typeof returnHolderSchema>

--- a/app/schemas/maintenanceSchema.ts
+++ b/app/schemas/maintenanceSchema.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod'
+
+export const maintenanceSchema = z.object({
+  maintenanceAt: z.string().min(1, 'Date is required'),
+  note: z.string().min(1, 'Note is required')
+})
+
+export type MaintenanceSchema = z.output<typeof maintenanceSchema>

--- a/app/schemas/noteSchema.ts
+++ b/app/schemas/noteSchema.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod'
+
+export const noteSchema = z.object({
+  occuredAt: z.string().min(1, 'Date is required'),
+  note: z.string().min(1, 'Note is required')
+})
+
+export type NoteSchema = z.output<typeof noteSchema>

--- a/app/services/AssetHolderService.ts
+++ b/app/services/AssetHolderService.ts
@@ -1,4 +1,4 @@
-// ~/services/assetHolder.ts
+import { BaseService } from '~/services/base'
 import type {
   AssetHolder,
   AssetHolderResponse,
@@ -7,63 +7,28 @@ import type {
   ReturnAssetHolderPayload
 } from '~/types/assetHolder'
 
-export class AssetHolderService {
+export class AssetHolderService extends BaseService {
   private basePath = '/v1/asset'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  /**
-   * Get holders
-   * - Support pagination (page, limit)
-   * - Support search
-   * - If all = true, ignore pagination
-   */
   async getHolders(
     assetUuid: string,
-    params: {
-      all?: boolean
-      search?: string
-      page?: number
-      limit?: number
-    } = {}
+    params: { all?: boolean, search?: string, page?: number, limit?: number } = {}
   ): Promise<AssetHolderResponse> {
-    return await this.api<AssetHolderResponse>(
-      `${this.basePath}/${assetUuid}/holder`,
-      {
-        method: 'GET',
-        params,
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<AssetHolderResponse>(`${this.basePath}/${assetUuid}/holder`, {
+      method: 'GET',
+      params,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Get single holder by ID
-  async getHolderById(
-    assetUuid: string,
-    holderId: string
-  ): Promise<AssetHolderDetailResponse> {
-    return await this.api<AssetHolderDetailResponse>(
-      `${this.basePath}/${assetUuid}/holder/${holderId}`,
-      {
-        method: 'GET',
-        headers: this.getAuthHeader()
-      }
-    )
+  async getHolderById(assetUuid: string, holderId: string): Promise<AssetHolderDetailResponse> {
+    return await this.api<AssetHolderDetailResponse>(`${this.basePath}/${assetUuid}/holder/${holderId}`, {
+      method: 'GET',
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Assign new holder
-  async assignHolder(
-    assetUuid: string,
-    payload: AssignAssetHolderPayload
-  ): Promise<AssetHolder> {
+  async assignHolder(assetUuid: string, payload: AssignAssetHolderPayload): Promise<AssetHolder> {
     const formData = new FormData()
     formData.append('assignedAt', payload.assignedAt)
     formData.append('purpose', payload.purpose)
@@ -71,61 +36,35 @@ export class AssetHolderService {
     if (payload.attachments) {
       payload.attachments.forEach(file => formData.append('attachments', file))
     }
-
-    return await this.api<AssetHolder>(
-      `${this.basePath}/${assetUuid}/holder`,
-      {
-        method: 'POST',
-        body: formData as any,
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<AssetHolder>(`${this.basePath}/${assetUuid}/holder`, {
+      method: 'POST',
+      body: formData as any,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Return holder
-  async returnHolder(
-    assetUuid: string,
-    holderId: string,
-    payload: ReturnAssetHolderPayload
-  ): Promise<void> {
+  async returnHolder(assetUuid: string, holderId: string, payload: ReturnAssetHolderPayload): Promise<void> {
     const formData = new FormData()
     formData.append('returnedAt', payload.returnedAt)
     if (payload.attachments) {
       payload.attachments.forEach(file => formData.append('attachments', file))
     }
-
-    await this.api(
-      `${this.basePath}/${assetUuid}/holder/${holderId}`,
-      {
-        method: 'POST',
-        body: formData as any,
-        headers: this.getAuthHeader()
-      }
-    )
+    await this.api(`${this.basePath}/${assetUuid}/holder/${holderId}`, {
+      method: 'POST',
+      body: formData as any,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Request asset
-  async requestAsset(
-    assetUuid: string,
-    payload: {
-      purpose: string
-      image?: File | null
-    }
-  ): Promise<void> {
+  async requestAsset(assetUuid: string, payload: { purpose: string, image?: File | null }): Promise<void> {
     const formData = new FormData()
     formData.append('purpose', payload.purpose)
-    if (payload.image) {
-      formData.append('image', payload.image)
-    }
-
-    await this.api(
-      `${this.basePath}/${assetUuid}/holder/request`,
-      {
-        method: 'POST',
-        body: formData as any,
-        headers: this.getAuthHeader()
-      }
-    )
+    if (payload.image) formData.append('image', payload.image)
+    await this.api(`${this.basePath}/${assetUuid}/holder/request`, {
+      method: 'POST',
+      body: formData as any,
+      headers: this.getAuthHeader()
+    })
   }
 }
 

--- a/app/services/AssetLocationService.ts
+++ b/app/services/AssetLocationService.ts
@@ -1,55 +1,30 @@
-// ~/services/assetLocation.ts
+import { BaseService } from '~/services/base'
 import type {
   AssetLocation,
   AssetLocationResponse,
   CreateAssetLocationPayload
 } from '~/types/assetLocation'
 
-export class AssetLocationService {
+export class AssetLocationService extends BaseService {
   private basePath = '/v1/asset'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getLocations(
     assetUuid: string,
-    params: {
-      all?: boolean
-      search?: string
-      page?: number
-      limit?: number
-    } = {}
+    params: { all?: boolean, search?: string, page?: number, limit?: number } = {}
   ): Promise<AssetLocationResponse> {
-    return await this.api<AssetLocationResponse>(
-      `${this.basePath}/${assetUuid}/location`,
-      {
-        method: 'GET',
-        params,
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<AssetLocationResponse>(`${this.basePath}/${assetUuid}/location`, {
+      method: 'GET',
+      params,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Create new location
-  async createLocation(
-    assetUuid: string,
-    payload: CreateAssetLocationPayload
-  ): Promise<AssetLocation> {
-    return await this.api<AssetLocation>(
-      `${this.basePath}/${assetUuid}/location`,
-      {
-        method: 'POST',
-        body: payload,
-        headers: this.getAuthHeader()
-      }
-    )
+  async createLocation(assetUuid: string, payload: CreateAssetLocationPayload): Promise<AssetLocation> {
+    return await this.api<AssetLocation>(`${this.basePath}/${assetUuid}/location`, {
+      method: 'POST',
+      body: payload,
+      headers: this.getAuthHeader()
+    })
   }
 }
 

--- a/app/services/AssetMaintenanceService.ts
+++ b/app/services/AssetMaintenanceService.ts
@@ -1,4 +1,4 @@
-// ~/services/assetMaintenance.ts
+import { BaseService } from '~/services/base'
 import type {
   AssetMaintenance,
   AssetMaintenanceResponse,
@@ -7,101 +7,48 @@ import type {
   UpdateAssetMaintenancePayload
 } from '~/types/assetMaintenance'
 
-export class AssetMaintenanceService {
+export class AssetMaintenanceService extends BaseService {
   private basePath = '/v1/asset'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  /**
-   * Get maintenances
-   * - Support pagination (page, limit)
-   * - Support search
-   * - If all = true, ignore pagination
-   */
   async getMaintenances(
     assetUuid: string,
-    params: {
-      all?: boolean
-      search?: string
-      page?: number
-      limit?: number
-    } = {}
+    params: { all?: boolean, search?: string, page?: number, limit?: number } = {}
   ): Promise<AssetMaintenanceResponse> {
-    return await this.api<AssetMaintenanceResponse>(
-      `${this.basePath}/${assetUuid}/maintenance`,
-      {
-        method: 'GET',
-        params,
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<AssetMaintenanceResponse>(`${this.basePath}/${assetUuid}/maintenance`, {
+      method: 'GET',
+      params,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Get single maintenance by ID
-  async getMaintenanceById(
-    assetUuid: string,
-    maintenanceId: string
-  ): Promise<AssetMaintenanceDetailResponse> {
-    return await this.api<AssetMaintenanceDetailResponse>(
-      `${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`,
-      {
-        method: 'GET',
-        headers: this.getAuthHeader()
-      }
-    )
+  async getMaintenanceById(assetUuid: string, maintenanceId: string): Promise<AssetMaintenanceDetailResponse> {
+    return await this.api<AssetMaintenanceDetailResponse>(`${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`, {
+      method: 'GET',
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Create new maintenance
-  async createMaintenance(
-    assetUuid: string,
-    payload: CreateAssetMaintenancePayload
-  ): Promise<AssetMaintenance> {
-    return await this.api<AssetMaintenance>(
-      `${this.basePath}/${assetUuid}/maintenance`,
-      {
-        method: 'POST',
-        body: payload,
-        headers: this.getAuthHeader()
-      }
-    )
+  async createMaintenance(assetUuid: string, payload: CreateAssetMaintenancePayload): Promise<AssetMaintenance> {
+    return await this.api<AssetMaintenance>(`${this.basePath}/${assetUuid}/maintenance`, {
+      method: 'POST',
+      body: payload,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Update maintenance
-  async updateMaintenance(
-    assetUuid: string,
-    maintenanceId: string,
-    payload: UpdateAssetMaintenancePayload
-  ): Promise<void> {
-    await this.api(
-      `${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`,
-      {
-        method: 'PUT',
-        body: payload,
-        headers: this.getAuthHeader()
-      }
-    )
+  async updateMaintenance(assetUuid: string, maintenanceId: string, payload: UpdateAssetMaintenancePayload): Promise<void> {
+    await this.api(`${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`, {
+      method: 'PUT',
+      body: payload,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Delete maintenance
-  async deleteMaintenance(
-    assetUuid: string,
-    maintenanceId: string
-  ): Promise<void> {
-    await this.api(
-      `${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`,
-      {
-        method: 'DELETE',
-        headers: this.getAuthHeader()
-      }
-    )
+  async deleteMaintenance(assetUuid: string, maintenanceId: string): Promise<void> {
+    await this.api(`${this.basePath}/${assetUuid}/maintenance/${maintenanceId}`, {
+      method: 'DELETE',
+      headers: this.getAuthHeader()
+    })
   }
 }
 

--- a/app/services/AssetNoteService.ts
+++ b/app/services/AssetNoteService.ts
@@ -1,4 +1,4 @@
-// ~/services/assetMaintenance.ts
+import { BaseService } from '~/services/base'
 import type {
   AssetNote,
   AssetNoteResponse,
@@ -7,101 +7,48 @@ import type {
   UpdateAssetNotePayload
 } from '~/types/assetNote'
 
-export class AssetNoteService {
+export class AssetNoteService extends BaseService {
   private basePath = '/v1/asset'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  /**
-   * Get maintenances
-   * - Support pagination (page, limit)
-   * - Support search
-   * - If all = true, ignore pagination
-   */
   async getNotes(
     assetUuid: string,
-    params: {
-      all?: boolean
-      search?: string
-      page?: number
-      limit?: number
-    } = {}
+    params: { all?: boolean, search?: string, page?: number, limit?: number } = {}
   ): Promise<AssetNoteResponse> {
-    return await this.api<AssetNoteResponse>(
-      `${this.basePath}/${assetUuid}/note`,
-      {
-        method: 'GET',
-        params,
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<AssetNoteResponse>(`${this.basePath}/${assetUuid}/note`, {
+      method: 'GET',
+      params,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Get single maintenance by ID
-  async getNoteById(
-    assetUuid: string,
-    noteId: string
-  ): Promise<AssetNoteDetailResponse> {
-    return await this.api<AssetNoteDetailResponse>(
-      `${this.basePath}/${assetUuid}/note/${noteId}`,
-      {
-        method: 'GET',
-        headers: this.getAuthHeader()
-      }
-    )
+  async getNoteById(assetUuid: string, noteId: string): Promise<AssetNoteDetailResponse> {
+    return await this.api<AssetNoteDetailResponse>(`${this.basePath}/${assetUuid}/note/${noteId}`, {
+      method: 'GET',
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Create new maintenance
-  async createNote(
-    assetUuid: string,
-    payload: CreateAssetNotePayload
-  ): Promise<AssetNote> {
-    return await this.api<AssetNote>(
-      `${this.basePath}/${assetUuid}/note`,
-      {
-        method: 'POST',
-        body: payload,
-        headers: this.getAuthHeader()
-      }
-    )
+  async createNote(assetUuid: string, payload: CreateAssetNotePayload): Promise<AssetNote> {
+    return await this.api<AssetNote>(`${this.basePath}/${assetUuid}/note`, {
+      method: 'POST',
+      body: payload,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Update maintenance
-  async updateNote(
-    assetUuid: string,
-    noteId: string,
-    payload: UpdateAssetNotePayload
-  ): Promise<void> {
-    await this.api(
-      `${this.basePath}/${assetUuid}/note/${noteId}`,
-      {
-        method: 'PUT',
-        body: payload,
-        headers: this.getAuthHeader()
-      }
-    )
+  async updateNote(assetUuid: string, noteId: string, payload: UpdateAssetNotePayload): Promise<void> {
+    await this.api(`${this.basePath}/${assetUuid}/note/${noteId}`, {
+      method: 'PUT',
+      body: payload,
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Delete maintenance
-  async deleteNote(
-    assetUuid: string,
-    noteId: string
-  ): Promise<void> {
-    await this.api(
-      `${this.basePath}/${assetUuid}/note/${noteId}`,
-      {
-        method: 'DELETE',
-        headers: this.getAuthHeader()
-      }
-    )
+  async deleteNote(assetUuid: string, noteId: string): Promise<void> {
+    await this.api(`${this.basePath}/${assetUuid}/note/${noteId}`, {
+      method: 'DELETE',
+      headers: this.getAuthHeader()
+    })
   }
 }
 

--- a/app/services/AssetService.ts
+++ b/app/services/AssetService.ts
@@ -1,43 +1,37 @@
+import { BaseService } from '~/services/base'
 import type {
   AssetDetailResponse,
   AssetResponse,
+  AssetFilterOptions,
+  AssetExportOptions,
   CreateAssetPayload,
-  ImportAssetPayload,
   UpdateAssetPayload
 } from '~/types/asset'
 
-export class AssetService {
+export class AssetService extends BaseService {
   private basePath = '/v1/asset'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
+  async getAssets(options: AssetFilterOptions = {}): Promise<AssetResponse> {
+    const {
+      search = '',
+      page = 1,
+      limit = 10,
+      user,
+      categoryId,
+      subCategoryId,
+      status,
+      employeeId,
+      locationId,
+      branchId,
+      startDate,
+      endDate,
+      hasHolder,
+      isLendable,
+      labels,
+      sort,
+      order
+    } = options
 
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  async getAssets(
-    search = '',
-    page = 1,
-    limit = 10,
-    user: string | null = null,
-    categoryId: string | null = null,
-    subCategoryId: string | null = null,
-    status: string | null = null,
-    employeeId: string | null = null,
-    locationId: string | null = null,
-    branchId: string | null = null,
-    startDate: string | null = null,
-    endDate: string | null = null,
-    hasHolder: boolean | null = false,
-    isLendable: boolean | null = null,
-    labels: string | null = null,
-    sort: string | null = null,
-    order: string | null = null
-  ): Promise<AssetResponse> {
     const params: Record<string, any> = { search, page, limit }
     if (user) params.user = user
     if (categoryId) params.categoryId = categoryId
@@ -48,8 +42,8 @@ export class AssetService {
     if (branchId) params.branchId = branchId
     if (startDate) params.startDate = startDate
     if (endDate) params.endDate = endDate
-    if (hasHolder !== null) params.hasHolder = hasHolder
-    if (isLendable !== null) params.isLendable = isLendable
+    if (hasHolder !== null && hasHolder !== undefined) params.hasHolder = hasHolder
+    if (isLendable !== null && isLendable !== undefined) params.isLendable = isLendable
     if (labels) params.labels = labels
     if (sort) params.sort = sort
     if (order) params.order = order
@@ -131,34 +125,21 @@ export class AssetService {
     })
   }
 
-  async exportAssets(
-    user: string | null = null,
-    categoryId: string | null = null,
-    subCategoryId: string | null = null,
-    status: string | null = null,
-    employeeId: string | null = null,
-    locationId: string | null = null,
-    branchId: string | null = null,
-    startDate: string | null = null,
-    endDate: string | null = null,
-    isLendable: boolean | null = null,
-    labels: string | null = null
-  ): Promise<{ blob: Blob, filename: string }> {
+  async exportAssets(options: AssetExportOptions = {}): Promise<{ blob: Blob, filename: string }> {
     const config = useRuntimeConfig()
-
     const params: Record<string, any> = {}
 
-    if (user) params.user = user
-    if (categoryId) params.categoryId = categoryId
-    if (subCategoryId) params.subCategoryId = subCategoryId
-    if (status) params.status = status
-    if (employeeId) params.employeeId = employeeId
-    if (locationId) params.locationId = locationId
-    if (branchId) params.branchId = branchId
-    if (startDate) params.startDate = startDate
-    if (endDate) params.endDate = endDate
-    if (isLendable !== null) params.isLendable = isLendable
-    if (labels) params.labels = labels
+    if (options.user) params.user = options.user
+    if (options.categoryId) params.categoryId = options.categoryId
+    if (options.subCategoryId) params.subCategoryId = options.subCategoryId
+    if (options.status) params.status = options.status
+    if (options.employeeId) params.employeeId = options.employeeId
+    if (options.locationId) params.locationId = options.locationId
+    if (options.branchId) params.branchId = options.branchId
+    if (options.startDate) params.startDate = options.startDate
+    if (options.endDate) params.endDate = options.endDate
+    if (options.isLendable !== null && options.isLendable !== undefined) params.isLendable = options.isLendable
+    if (options.labels) params.labels = options.labels
 
     const queryString = new URLSearchParams(params).toString()
     const url = `${config.public.apiUrl}${this.basePath}/export${queryString ? `?${queryString}` : ''}`
@@ -169,7 +150,6 @@ export class AssetService {
     })
 
     const blob = await response.blob()
-
     const contentDisposition = response.headers.get('content-disposition')
     let filename = ''
 
@@ -185,6 +165,7 @@ export class AssetService {
       const dateStr = today.toISOString().split('T')[0]
       filename = `export-assets-${dateStr}.xlsx`
     }
+
     return { blob, filename }
   }
 

--- a/app/services/AssetStatusService.ts
+++ b/app/services/AssetStatusService.ts
@@ -1,3 +1,5 @@
+import { BaseService } from '~/services/base'
+
 export interface CreateAssetStatusPayload {
   type: 'active' | 'sold' | 'granted' | 'disposed'
   note?: string
@@ -14,18 +16,8 @@ export interface AssetStatusResponse {
   }
 }
 
-export class AssetStatusService {
+export class AssetStatusService extends BaseService {
   private basePath = '/v1/asset'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async updateStatus(assetUuid: string, payload: CreateAssetStatusPayload): Promise<{ data: AssetStatusResponse }> {
     return await this.api<{ data: AssetStatusResponse }>(`${this.basePath}/${assetUuid}/status`, {
@@ -35,7 +27,7 @@ export class AssetStatusService {
     })
   }
 
-  async getStatuses(assetUuid: string, page: number = 1, limit: number = 10, search: string = ''): Promise<{ data: AssetStatusResponse[], meta?: any }> {
+  async getStatuses(assetUuid: string, page = 1, limit = 10, search = ''): Promise<{ data: AssetStatusResponse[], meta?: any }> {
     return await this.api<{ data: AssetStatusResponse[], meta?: any }>(`${this.basePath}/${assetUuid}/status`, {
       method: 'GET',
       params: { page, limit, search },

--- a/app/services/BookService.ts
+++ b/app/services/BookService.ts
@@ -1,17 +1,8 @@
+import { BaseService } from '~/services/base'
 import type { BookResponse, LoanListResponse } from '~/types/book'
 
-export class BookService {
+export class BookService extends BaseService {
   private basePath = '/v2/book'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getBookByCode(code: string): Promise<BookResponse> {
     return await this.api<BookResponse>(`${this.basePath}/${code}`, {
@@ -24,7 +15,6 @@ export class BookService {
     const formData = new FormData()
     formData.append('assetId', assetId)
     formData.append('image', image)
-
     return await this.api<any>(`${this.basePath}/loan/assign`, {
       method: 'POST',
       body: formData,
@@ -44,7 +34,6 @@ export class BookService {
     formData.append('assetHolderId', assetHolderId)
     formData.append('purpose', purpose)
     formData.append('image', image)
-
     return await this.api<any>(`${this.basePath}/loan/return`, {
       method: 'POST',
       body: formData,

--- a/app/services/BranchService.ts
+++ b/app/services/BranchService.ts
@@ -1,17 +1,8 @@
+import { BaseService } from '~/services/base'
 import type { BranchResponse } from '~/types/branch'
 
-export class BranchService {
+export class BranchService extends BaseService {
   private basePath = '/v1/branch'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getAllBranches(search = ''): Promise<BranchResponse> {
     return await this.api<BranchResponse>(this.basePath, {

--- a/app/services/CategoryService.ts
+++ b/app/services/CategoryService.ts
@@ -1,20 +1,10 @@
+import { BaseService } from '~/services/base'
 import type { Category, CategoryDetailResponse, CategoryResponse, CreateCategoryPayload, UpdateCategoryPayload } from '~/types/category'
 import type { SubCategoryResponse } from '~/types/subCategory'
 
-export class CategoryService {
+export class CategoryService extends BaseService {
   private basePath = '/v1/category'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  // Fetch paginate categories with pagination
   async getCategories(search = '', page = 1, limit = 10): Promise<CategoryResponse> {
     return await this.api<CategoryResponse>(this.basePath, {
       method: 'GET',
@@ -23,7 +13,6 @@ export class CategoryService {
     })
   }
 
-  // Fetch all categories with pagination
   async getAllCategories(all = true): Promise<CategoryResponse> {
     return await this.api<CategoryResponse>(this.basePath, {
       method: 'GET',
@@ -39,7 +28,6 @@ export class CategoryService {
     })
   }
 
-  // Fetch single category by ID
   async getCategoryById(id: string): Promise<CategoryDetailResponse> {
     return await this.api<CategoryDetailResponse>(`${this.basePath}/${id}`, {
       method: 'GET',
@@ -47,7 +35,6 @@ export class CategoryService {
     })
   }
 
-  // Create a new category
   async createCategory(payload: CreateCategoryPayload): Promise<Category> {
     return await this.api<Category>(this.basePath, {
       method: 'POST',
@@ -56,7 +43,6 @@ export class CategoryService {
     })
   }
 
-  // Update existing category
   async updateCategory(id: string, payload: UpdateCategoryPayload): Promise<void> {
     await this.api(`${this.basePath}/${id}`, {
       method: 'PUT',
@@ -65,7 +51,6 @@ export class CategoryService {
     })
   }
 
-  // Delete a category
   async deleteCategory(id: string): Promise<void> {
     await this.api(`${this.basePath}/${id}`, {
       method: 'DELETE',

--- a/app/services/EmployeeService.ts
+++ b/app/services/EmployeeService.ts
@@ -1,18 +1,8 @@
-// ~/services/EmployeeService.ts
+import { BaseService } from '~/services/base'
 import type { EmployeeResponse } from '~/types/employee'
 
-export class EmployeeService {
+export class EmployeeService extends BaseService {
   private basePath = '/v1/employee'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getAllEmployees(search = ''): Promise<EmployeeResponse> {
     return await this.api<EmployeeResponse>(this.basePath, {

--- a/app/services/FeedbackService.ts
+++ b/app/services/FeedbackService.ts
@@ -1,3 +1,4 @@
+import { BaseService } from '~/services/base'
 import type {
   Feedback,
   FeedbackDetailResponse,
@@ -6,32 +7,10 @@ import type {
   UpdateFeedbackPayload
 } from '~/types/feedback'
 
-export class FeedbackService {
+export class FeedbackService extends BaseService {
   private basePath = '/feedback'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  /**
-   * Get paginated feedbacks (by user or all)
-   * @param search optional search keyword
-   * @param page page number (default: 1)
-   * @param limit items per page (default: 10)
-   * @param byUser filter feedback by current user (default: true)
-   */
-  async getFeedbacks(
-    search = '',
-    page = 1,
-    limit = 10,
-    byUser = true
-  ): Promise<FeedbackResponse> {
+  async getFeedbacks(search = '', page = 1, limit = 10, byUser = true): Promise<FeedbackResponse> {
     return await this.api<FeedbackResponse>(this.basePath, {
       method: 'GET',
       params: { search, page, limit, 'by-user': byUser },
@@ -60,7 +39,6 @@ export class FeedbackService {
     formData.append('type', payload.type)
     formData.append('description', payload.description)
     payload.images?.forEach(file => formData.append('images', file))
-
     return await this.api<Feedback>(this.basePath, {
       method: 'POST',
       body: formData,

--- a/app/services/LocationService.ts
+++ b/app/services/LocationService.ts
@@ -1,17 +1,8 @@
+import { BaseService } from '~/services/base'
 import type { LocationDetailResponse, LocationResponse, CreateLocationPayload, UpdateLocationPayload } from '~/types/location'
 
-export class LocationService {
+export class LocationService extends BaseService {
   private basePath = '/v1/location'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getLocations(search = '', page = 1, limit = 10): Promise<LocationResponse> {
     return await this.api<LocationResponse>(this.basePath, {

--- a/app/services/PropertyService.ts
+++ b/app/services/PropertyService.ts
@@ -1,3 +1,4 @@
+import { BaseService } from '~/services/base'
 import type {
   Property,
   PropertyDetailResponse,
@@ -6,26 +7,10 @@ import type {
   UpdatePropertyPayload
 } from '~/types/property'
 
-export class PropertyService {
+export class PropertyService extends BaseService {
   private basePath = '/v1/sub-category'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  // Fetch paginate properties with pagination
-  async getProperties(
-    subCategoryId: string,
-    search = '',
-    page = 1,
-    limit = 10
-  ): Promise<PropertyResponse> {
+  async getProperties(subCategoryId: string, search = '', page = 1, limit = 10): Promise<PropertyResponse> {
     return await this.api<PropertyResponse>(`${this.basePath}/${subCategoryId}/property`, {
       method: 'GET',
       params: { search, page, limit },
@@ -33,7 +18,6 @@ export class PropertyService {
     })
   }
 
-  // Fetch all properties (without pagination, optional all flag)
   async getAllProperties(subCategoryId: string, all = true): Promise<PropertyResponse> {
     return await this.api<PropertyResponse>(`${this.basePath}/${subCategoryId}/property`, {
       method: 'GET',
@@ -42,7 +26,6 @@ export class PropertyService {
     })
   }
 
-  // Fetch single property by ID
   async getPropertyById(subCategoryId: string, propertyId: string): Promise<PropertyDetailResponse> {
     return await this.api<PropertyDetailResponse>(`${this.basePath}/${subCategoryId}/property/${propertyId}`, {
       method: 'GET',
@@ -50,7 +33,6 @@ export class PropertyService {
     })
   }
 
-  // Create a new property
   async createProperty(subCategoryId: string, payload: CreatePropertyPayload): Promise<Property> {
     return await this.api<Property>(`${this.basePath}/${subCategoryId}/property`, {
       method: 'POST',
@@ -59,12 +41,7 @@ export class PropertyService {
     })
   }
 
-  // Update existing property
-  async updateProperty(
-    subCategoryId: string,
-    propertyId: string,
-    payload: UpdatePropertyPayload
-  ): Promise<void> {
+  async updateProperty(subCategoryId: string, propertyId: string, payload: UpdatePropertyPayload): Promise<void> {
     await this.api(`${this.basePath}/${subCategoryId}/property/${propertyId}`, {
       method: 'PUT',
       body: payload,
@@ -72,7 +49,6 @@ export class PropertyService {
     })
   }
 
-  // Delete a property
   async deleteProperty(subCategoryId: string, propertyId: string): Promise<void> {
     await this.api(`${this.basePath}/${subCategoryId}/property/${propertyId}`, {
       method: 'DELETE',

--- a/app/services/StatisticService.ts
+++ b/app/services/StatisticService.ts
@@ -1,3 +1,4 @@
+import { BaseService } from '~/services/base'
 import type {
   CountResponse,
   AssetByCategoryResponse,
@@ -9,20 +10,9 @@ import type {
   DataQualityResponse
 } from '~/types/statistic'
 
-export class StatisticService {
+export class StatisticService extends BaseService {
   private basePath = '/v1/statistic'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  // Get total counts
   async getCount(): Promise<CountResponse> {
     return await this.api<CountResponse>(`${this.basePath}/count`, {
       method: 'GET',
@@ -30,7 +20,6 @@ export class StatisticService {
     })
   }
 
-  // Get assets grouped by category
   async getAssetsByCategory(): Promise<AssetByCategoryResponse> {
     return await this.api<AssetByCategoryResponse>(`${this.basePath}/assets-by-category`, {
       method: 'GET',
@@ -38,7 +27,6 @@ export class StatisticService {
     })
   }
 
-  // Get assets grouped by sub-category
   async getAssetsBySubCategory(): Promise<AssetBySubCategoryResponse> {
     return await this.api<AssetBySubCategoryResponse>(`${this.basePath}/assets-by-sub-category`, {
       method: 'GET',
@@ -46,7 +34,6 @@ export class StatisticService {
     })
   }
 
-  // Get assets grouped by location
   async getAssetsByLocation(): Promise<AssetByLocationResponse> {
     return await this.api<AssetByLocationResponse>(`${this.basePath}/assets-by-location`, {
       method: 'GET',
@@ -54,7 +41,6 @@ export class StatisticService {
     })
   }
 
-  // Get price by category
   async getPriceByCategory(): Promise<CategoryPriceResponse> {
     return await this.api<CategoryPriceResponse>(`${this.basePath}/price-by-category`, {
       method: 'GET',
@@ -62,7 +48,6 @@ export class StatisticService {
     })
   }
 
-  // Get price by location
   async getPriceByLocation(): Promise<LocationPriceResponse> {
     return await this.api<LocationPriceResponse>(`${this.basePath}/price-by-location`, {
       method: 'GET',
@@ -70,7 +55,6 @@ export class StatisticService {
     })
   }
 
-  // Get asset aging
   async getAssetAging(): Promise<AssetAgingResponse> {
     return await this.api<AssetAgingResponse>(`${this.basePath}/asset-aging`, {
       method: 'GET',
@@ -78,7 +62,6 @@ export class StatisticService {
     })
   }
 
-  // Get data quality
   async getDataQuality(): Promise<DataQualityResponse> {
     return await this.api<DataQualityResponse>(`${this.basePath}/data-quality`, {
       method: 'GET',

--- a/app/services/SubCategoryService.ts
+++ b/app/services/SubCategoryService.ts
@@ -1,3 +1,4 @@
+import { BaseService } from '~/services/base'
 import type {
   SubCategory,
   SubCategoryDetailResponse,
@@ -8,26 +9,12 @@ import type {
   UpdateSubCategoryPayload
 } from '~/types/subCategory'
 
-export class SubCategoryService {
+export class SubCategoryService extends BaseService {
   private basePath = '/v1/sub-category'
 
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
-
-  // Fetch all sub-categories with pagination
   async getSubCategories(search = '', page = 1, limit = 10, categoryUuid?: string): Promise<SubCategoryResponse> {
     const params: Record<string, any> = { search, page, limit }
-    if (categoryUuid) {
-      params.categoryUuid = categoryUuid
-    }
-
+    if (categoryUuid) params.categoryUuid = categoryUuid
     return await this.api<SubCategoryResponse>(this.basePath, {
       method: 'GET',
       params,
@@ -35,29 +22,20 @@ export class SubCategoryService {
     })
   }
 
-  // Fetch hierarchy tree for a category
   async getHierarchyTree(categoryUuid: string): Promise<SubCategoryHierarchyResponse> {
-    return await this.api<SubCategoryHierarchyResponse>(
-      `${this.basePath}/category/${categoryUuid}/hierarchy`,
-      {
-        method: 'GET',
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<SubCategoryHierarchyResponse>(`${this.basePath}/category/${categoryUuid}/hierarchy`, {
+      method: 'GET',
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Fetch all sub-categories by category (flat list)
   async getSubCategoriesByCategory(categoryUuid: string): Promise<SubCategoryHierarchyResponse> {
-    return await this.api<SubCategoryHierarchyResponse>(
-      `${this.basePath}/category/${categoryUuid}`,
-      {
-        method: 'GET',
-        headers: this.getAuthHeader()
-      }
-    )
+    return await this.api<SubCategoryHierarchyResponse>(`${this.basePath}/category/${categoryUuid}`, {
+      method: 'GET',
+      headers: this.getAuthHeader()
+    })
   }
 
-  // Fetch single sub-category by ID
   async getSubCategoryById(id: string): Promise<SubCategoryDetailResponse> {
     return await this.api<SubCategoryDetailResponse>(`${this.basePath}/${id}`, {
       method: 'GET',
@@ -65,7 +43,6 @@ export class SubCategoryService {
     })
   }
 
-  // Get path (breadcrumb) from root to node
   async getSubCategoryPath(id: string): Promise<SubCategoryPathResponse> {
     return await this.api<SubCategoryPathResponse>(`${this.basePath}/${id}/path`, {
       method: 'GET',
@@ -73,7 +50,6 @@ export class SubCategoryService {
     })
   }
 
-  // Create a new sub-category
   async createSubCategory(payload: CreateSubCategoryPayload): Promise<SubCategoryDetailResponse> {
     return await this.api<SubCategoryDetailResponse>(this.basePath, {
       method: 'POST',
@@ -82,7 +58,6 @@ export class SubCategoryService {
     })
   }
 
-  // Update existing sub-category
   async updateSubCategory(id: string, payload: UpdateSubCategoryPayload): Promise<SubCategoryDetailResponse> {
     return await this.api<SubCategoryDetailResponse>(`${this.basePath}/${id}`, {
       method: 'PUT',
@@ -91,7 +66,6 @@ export class SubCategoryService {
     })
   }
 
-  // Delete a sub-category
   async deleteSubCategory(id: string): Promise<void> {
     await this.api(`${this.basePath}/${id}`, {
       method: 'DELETE',

--- a/app/services/UserAssetService.ts
+++ b/app/services/UserAssetService.ts
@@ -1,17 +1,8 @@
+import { BaseService } from '~/services/base'
 import type { UserAssetResponse } from '~/types/userAsset'
 
-export class UserAssetService {
+export class UserAssetService extends BaseService {
   private basePath = '/v1/user/my-assets'
-
-  private get api() {
-    const { $api } = useNuxtApp()
-    return $api
-  }
-
-  private getAuthHeader() {
-    const token = localStorage.getItem('accessToken') || ''
-    return { Authorization: `Bearer ${token}` }
-  }
 
   async getActiveAssets(page = 1, limit = 10): Promise<UserAssetResponse> {
     return await this.api<UserAssetResponse>(`${this.basePath}/active`, {
@@ -32,7 +23,6 @@ export class UserAssetService {
   async returnRequest(assetUuid: string, uuid: string, payload: { image: File }): Promise<void> {
     const formData = new FormData()
     formData.append('image', payload.image)
-
     return await this.api(`/v1/asset/${assetUuid}/holder/${uuid}/return-request`, {
       method: 'POST',
       body: formData as any,

--- a/app/services/base.ts
+++ b/app/services/base.ts
@@ -1,0 +1,11 @@
+export class BaseService {
+  protected get api() {
+    const { $api } = useNuxtApp()
+    return $api
+  }
+
+  protected getAuthHeader(): { Authorization: string } {
+    const token = localStorage.getItem('accessToken') || ''
+    return { Authorization: `Bearer ${token}` }
+  }
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,3 +1,28 @@
 export interface ApiError {
   message: string
 }
+
+export interface Pagination {
+  totalItems: number
+  itemCount: number
+  itemsPerPage: number
+  totalPages: number
+  currentPage: number
+}
+
+export interface ApiListResponse<T> {
+  success: boolean
+  statusCode: number
+  message: string
+  data: T[]
+  meta?: {
+    pagination: Pagination
+  }
+}
+
+export interface ApiDetailResponse<T> {
+  success: boolean
+  statusCode: number
+  message: string
+  data: T
+}

--- a/app/types/asset.ts
+++ b/app/types/asset.ts
@@ -1,3 +1,5 @@
+import type { Pagination } from './api'
+
 export interface AssetPropertyPayload {
   id: string
   value: string | number
@@ -42,6 +44,40 @@ export interface UpdateAssetPayload {
   labels?: AssetLabel[]
   image?: File | null
   isLendable: boolean
+}
+
+export interface AssetFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+  user?: string | null
+  categoryId?: string | null
+  subCategoryId?: string | null
+  status?: string | null
+  employeeId?: string | null
+  locationId?: string | null
+  branchId?: string | null
+  startDate?: string | null
+  endDate?: string | null
+  hasHolder?: boolean | null
+  isLendable?: boolean | null
+  labels?: string | null
+  sort?: string | null
+  order?: string | null
+}
+
+export interface AssetExportOptions {
+  user?: string | null
+  categoryId?: string | null
+  subCategoryId?: string | null
+  status?: string | null
+  employeeId?: string | null
+  locationId?: string | null
+  branchId?: string | null
+  startDate?: string | null
+  endDate?: string | null
+  isLendable?: boolean | null
+  labels?: string | null
 }
 
 export interface AssetHolder {
@@ -121,14 +157,6 @@ export interface Asset {
   lastLocation?: AssetLocation | null
 }
 
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
 export interface AssetResponse {
   success: boolean
   statusCode: number
@@ -145,3 +173,5 @@ export interface AssetDetailResponse {
   message: string
   data: Asset
 }
+
+export type { Pagination }

--- a/app/types/assetHolder.ts
+++ b/app/types/assetHolder.ts
@@ -1,6 +1,5 @@
-// ~/types/assetHolder.ts
-
 import type { Employee } from './employee'
+import type { Pagination } from './api'
 
 export interface AssetHolder {
   id: string
@@ -15,7 +14,6 @@ export interface AssetHolder {
   updatedAt?: string
 }
 
-// Payload for assign
 export interface AssignAssetHolderPayload {
   assignedAt: string
   purpose: string
@@ -23,22 +21,11 @@ export interface AssignAssetHolderPayload {
   attachments?: File[]
 }
 
-// Payload for return
 export interface ReturnAssetHolderPayload {
   returnedAt: string
   attachments?: File[]
 }
 
-// Pagination
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
-// Response for multiple holders
 export interface AssetHolderResponse {
   success: boolean
   statusCode: number
@@ -49,10 +36,11 @@ export interface AssetHolderResponse {
   }
 }
 
-// Response for single holder
 export interface AssetHolderDetailResponse {
   success: boolean
   statusCode: number
   message: string
   data: AssetHolder
 }
+
+export type { Pagination }

--- a/app/types/assetLocation.ts
+++ b/app/types/assetLocation.ts
@@ -1,14 +1,4 @@
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
-export interface MetaPagination {
-  pagination: Pagination
-}
+import type { Pagination } from './api'
 
 export interface CreateAssetLocationPayload {
   locationId: string
@@ -30,5 +20,9 @@ export interface AssetLocationResponse {
   statusCode: number
   message: string
   data: AssetLocation[]
-  meta: MetaPagination
+  meta: {
+    pagination: Pagination
+  }
 }
+
+export type { Pagination }

--- a/app/types/assetMaintenance.ts
+++ b/app/types/assetMaintenance.ts
@@ -1,32 +1,22 @@
+import type { Pagination } from './api'
+
 export interface AssetMaintenance {
   id: string
   assetUuid: string
-  maintenanceAt: string // ISO date string, e.g. "2025-06-09"
+  maintenanceAt: string
   note: string
   createdAt?: string
   updatedAt?: string
 }
 
-// Payload for create
 export interface CreateAssetMaintenancePayload {
   maintenanceAt: string
   note: string
 }
 
-// Payload for update (optional fields)
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UpdateAssetMaintenancePayload extends Partial<CreateAssetMaintenancePayload> {}
 
-// Pagination
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
-// Response for multiple maintenances
 export interface AssetMaintenanceResponse {
   success: boolean
   statusCode: number
@@ -37,10 +27,11 @@ export interface AssetMaintenanceResponse {
   }
 }
 
-// Response for single maintenance
 export interface AssetMaintenanceDetailResponse {
   success: boolean
   statusCode: number
   message: string
   data: AssetMaintenance
 }
+
+export type { Pagination }

--- a/app/types/assetNote.ts
+++ b/app/types/assetNote.ts
@@ -1,32 +1,22 @@
+import type { Pagination } from './api'
+
 export interface AssetNote {
   id: string
   assetUuid: string
-  occuredAt: string // ISO date string, e.g. "2025-06-09"
+  occuredAt: string
   note: string
   createdAt?: string
   updatedAt?: string
 }
 
-// Payload for create
 export interface CreateAssetNotePayload {
   occuredAt: string
   note: string
 }
 
-// Payload for update (optional fields)
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UpdateAssetNotePayload extends Partial<CreateAssetNotePayload> {}
 
-// Pagination
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
-// Response for multiple maintenances
 export interface AssetNoteResponse {
   success: boolean
   statusCode: number
@@ -37,10 +27,11 @@ export interface AssetNoteResponse {
   }
 }
 
-// Response for single maintenance
 export interface AssetNoteDetailResponse {
   success: boolean
   statusCode: number
   message: string
   data: AssetNote
 }
+
+export type { Pagination }

--- a/app/types/category.ts
+++ b/app/types/category.ts
@@ -1,3 +1,5 @@
+import type { Pagination } from './api'
+
 export interface Category {
   data?: any
   id: string
@@ -5,14 +7,6 @@ export interface Category {
   hasLocation: boolean
   hasMaintenance: boolean
   hasHolder: boolean
-}
-
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
 }
 
 export interface CategoryResponse {
@@ -42,3 +36,5 @@ export interface CreateCategoryPayload {
 export interface UpdateCategoryPayload extends Partial<CreateCategoryPayload> {
   id?: string
 }
+
+export type { Pagination }

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -1,3 +1,5 @@
+import type { Pagination } from './api'
+
 export type FeedbackType = 'keluhan' | 'saran' | 'pujian'
 
 export const FeedbackTypeColor: Record<FeedbackType, string> = {
@@ -38,7 +40,6 @@ export interface Feedback {
   url?: string
 }
 
-/** Raw shape returned by the API before mapping */
 export interface FeedbackRaw {
   timestamp: string
   email: string
@@ -62,14 +63,6 @@ export interface FeedbackResponse {
   }
 }
 
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
 export interface CreateFeedbackPayload {
   url: string
   type: FeedbackType
@@ -81,3 +74,5 @@ export interface UpdateFeedbackPayload {
   status: FeedbackStatus
   reply: string
 }
+
+export type { Pagination }

--- a/app/types/location.ts
+++ b/app/types/location.ts
@@ -1,18 +1,11 @@
 import type { Branch } from './branch'
+import type { Pagination } from './api'
 
 export interface Location {
   locationUuid: any
   id: string
   name: string
   branch: Branch
-}
-
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
 }
 
 export interface LocationResponse {
@@ -40,3 +33,5 @@ export interface CreateLocationPayload {
 export interface UpdateLocationPayload extends Partial<CreateLocationPayload> {
   id?: string
 }
+
+export type { Pagination }

--- a/app/types/property.ts
+++ b/app/types/property.ts
@@ -1,4 +1,4 @@
-// ~/types/property.ts
+import type { Pagination } from './api'
 
 export interface Property {
   id: string
@@ -6,27 +6,15 @@ export interface Property {
   dataType: 'string' | 'number'
 }
 
-// Payload for creating a new property
 export interface CreatePropertyPayload {
   name: string
   dataType: 'string' | 'number'
 }
 
-// Payload for updating an existing property (optional fields)
 export interface UpdatePropertyPayload extends Partial<CreatePropertyPayload> {
   id?: string
 }
 
-// Pagination (reusable)
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
-// Response for multiple properties (paginated or all)
 export interface PropertyResponse {
   success: boolean
   statusCode: number
@@ -37,10 +25,11 @@ export interface PropertyResponse {
   }
 }
 
-// Response for single property detail
 export interface PropertyDetailResponse {
   success: boolean
   statusCode: number
   message: string
   data: Property
 }
+
+export type { Pagination }

--- a/app/types/subCategory.ts
+++ b/app/types/subCategory.ts
@@ -1,4 +1,4 @@
-// ~/types/subCategory.ts
+import type { Pagination } from './api'
 
 export interface AssetProperty {
   id: string
@@ -39,14 +39,6 @@ export interface UpdateSubCategoryPayload {
   labels?: string[]
 }
 
-export interface Pagination {
-  totalItems: number
-  itemCount: number
-  itemsPerPage: number
-  totalPages: number
-  currentPage: number
-}
-
 export interface SubCategoryResponse {
   success: boolean
   statusCode: number
@@ -77,3 +69,5 @@ export interface SubCategoryPathResponse {
   message: string
   data: SubCategory[]
 }
+
+export type { Pagination }

--- a/app/types/userAsset.ts
+++ b/app/types/userAsset.ts
@@ -1,5 +1,5 @@
 import type { Asset } from './asset'
-import type { Pagination } from './assetHolder'
+import type { Pagination } from './api'
 
 export interface UserAsset {
   id: string

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,0 +1,25 @@
+export function formatCalendarDate(date: { day: number, month: number, year: number } | null): string {
+  if (!date) return 'Select a date'
+  const day = String(date.day).padStart(2, '0')
+  const month = String(date.month).padStart(2, '0')
+  return `${day}/${month}/${date.year}`
+}
+
+export function calendarDateToISOString(date: { day: number, month: number, year: number }): string {
+  const month = String(date.month).padStart(2, '0')
+  const day = String(date.day).padStart(2, '0')
+  return `${date.year}-${month}-${day}`
+}
+
+export function formatDateLong(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-'
+  return new Date(dateStr).toLocaleDateString('id-ID', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+export function formatDateShort(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  const day = String(d.getDate()).padStart(2, '0')
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  return `${day}-${month}-${d.getFullYear()}`
+}

--- a/app/utils/errorHandler.ts
+++ b/app/utils/errorHandler.ts
@@ -1,0 +1,6 @@
+import type { FetchError } from 'ofetch'
+
+export function extractErrorMessage(err: unknown, fallback = 'Something went wrong'): string {
+  const fetchError = err as FetchError<{ message?: string }>
+  return fetchError?.data?.message ?? fallback
+}

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -1,0 +1,13 @@
+export function formatCurrency(value: number | string | null | undefined): string {
+  if (value === null || value === undefined) return '-'
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+  }).format(Number(value))
+}
+
+export function formatNumber(value: number): string {
+  return value.toLocaleString('en-US')
+}


### PR DESCRIPTION
## Summary

- **Types**: Consolidate `Pagination` and add generic `ApiListResponse<T>` / `ApiDetailResponse<T>` to `app/types/api.ts` — removes 10x duplicate `Pagination` interface
- **Services**: Create `BaseService` with shared `api()` and `getAuthHeader()` — all 16 service classes now `extend BaseService`, removing 17x copy-paste. Refactor `AssetService.getAssets()` from 17 positional params to `AssetFilterOptions` object
- **Utils**: Add `app/utils/errorHandler.ts` (`extractErrorMessage`), `app/utils/date.ts` (calendar date helpers), `app/utils/formatters.ts` (`formatCurrency`, `formatNumber`)
- **Composables**: Standardize all from `export const useX = () =>` to `export function useX()`. Replace all inline `FetchError<ApiError>` catch patterns with `extractErrorMessage()`. Update `useAsset` to use new filter object signatures
- **Schemas**: Extract Zod schemas from components into `app/schemas/` (maintenanceSchema, noteSchema, holderSchema)
- **Components**: Update 6 asset modals to use shared schemas and date utils. Update `HomeStats.vue` and `asset/[id]/detail.vue` to use shared formatters

Closes #72

## Test plan

- [ ] Asset listing loads and filters correctly
- [ ] Asset export works
- [ ] Maintenance add/update modals save correctly
- [ ] Note add/update modals save correctly
- [ ] Holder assign/return modals save correctly
- [ ] HomeStats displays correct currency and number formatting
- [ ] Asset detail page shows correct price format
- [ ] Auth login/logout flow works
- [ ] No TypeScript errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)