### PR TITLE
refactor(types): Shared Foundation — Konsolidasi Types (#73)

### DIFF
--- a/app/composables/useCategory.ts
+++ b/app/composables/useCategory.ts
@@ -52,7 +52,7 @@ export function useCategory(): CategoryState {
     try {
       const res = await categoryService.getCategories(search, page, limit)
       categories.value = res.data
-      apiPagination.value = res.meta.pagination
+      apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {
       error.value = extractErrorMessage(err, 'Failed to fetch categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })

--- a/app/composables/useLocation.ts
+++ b/app/composables/useLocation.ts
@@ -50,7 +50,7 @@ export function useLocation(): LocationState {
     try {
       const res = await locationService.getLocations(search, page, limit)
       locations.value = res.data
-      apiPagination.value = res.meta.pagination
+      apiPagination.value = res.meta?.pagination ?? null
       pagination.value.pageIndex = page - 1
     } catch (err: unknown) {
       error.value = extractErrorMessage(err, 'Failed to fetch locations')

--- a/app/composables/useSubCategory.ts
+++ b/app/composables/useSubCategory.ts
@@ -55,7 +55,7 @@ export function useSubCategory(): SubCategoryState {
     try {
       const res = await subCategoryService.getSubCategories(search, page, limit, categoryUuid)
       subCategories.value = res.data
-      apiPagination.value = res.meta.pagination
+      apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {
       error.value = extractErrorMessage(err, 'Failed to fetch sub-categories')
       toast.add({ title: 'Fetch failed', description: error.value, color: 'error' })

--- a/app/composables/useUserAsset.ts
+++ b/app/composables/useUserAsset.ts
@@ -16,8 +16,8 @@ export function useUserAsset() {
     try {
       const res = await userAssetService.getActiveAssets(page, limit)
       assets.value = res.data
-      apiPagination.value = res.meta.pagination
-      pagination.value.pageIndex = res.meta.pagination.currentPage - 1
+      apiPagination.value = res.meta?.pagination ?? null
+      pagination.value.pageIndex = (res.meta?.pagination?.currentPage ?? 1) - 1
     } catch (error) {
       // Handled globally
     } finally {
@@ -30,8 +30,8 @@ export function useUserAsset() {
     try {
       const res = await userAssetService.getHistoryAssets(page, limit)
       assets.value = res.data
-      apiPagination.value = res.meta.pagination
-      pagination.value.pageIndex = res.meta.pagination.currentPage - 1
+      apiPagination.value = res.meta?.pagination ?? null
+      pagination.value.pageIndex = (res.meta?.pagination?.currentPage ?? 1) - 1
     } catch (error) {
       // Handled globally
     } finally {

--- a/app/services/AssetStatusService.ts
+++ b/app/services/AssetStatusService.ts
@@ -1,4 +1,5 @@
 import { BaseService } from '~/services/base'
+import type { ApiDetailResponse, ApiListResponse } from '~/types/api'
 
 export interface CreateAssetStatusPayload {
   type: 'active' | 'sold' | 'granted' | 'disposed'
@@ -19,16 +20,16 @@ export interface AssetStatusResponse {
 export class AssetStatusService extends BaseService {
   private basePath = '/v1/asset'
 
-  async updateStatus(assetUuid: string, payload: CreateAssetStatusPayload): Promise<{ data: AssetStatusResponse }> {
-    return await this.api<{ data: AssetStatusResponse }>(`${this.basePath}/${assetUuid}/status`, {
+  async updateStatus(assetUuid: string, payload: CreateAssetStatusPayload): Promise<ApiDetailResponse<AssetStatusResponse>> {
+    return await this.api<ApiDetailResponse<AssetStatusResponse>>(`${this.basePath}/${assetUuid}/status`, {
       method: 'POST',
       body: payload,
       headers: this.getAuthHeader()
     })
   }
 
-  async getStatuses(assetUuid: string, page = 1, limit = 10, search = ''): Promise<{ data: AssetStatusResponse[], meta?: any }> {
-    return await this.api<{ data: AssetStatusResponse[], meta?: any }>(`${this.basePath}/${assetUuid}/status`, {
+  async getStatuses(assetUuid: string, page = 1, limit = 10, search = ''): Promise<ApiListResponse<AssetStatusResponse>> {
+    return await this.api<ApiListResponse<AssetStatusResponse>>(`${this.basePath}/${assetUuid}/status`, {
       method: 'GET',
       params: { page, limit, search },
       headers: this.getAuthHeader()

--- a/app/types/asset.ts
+++ b/app/types/asset.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface AssetPropertyPayload {
   id: string
@@ -157,21 +157,7 @@ export interface Asset {
   lastLocation?: AssetLocation | null
 }
 
-export interface AssetResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Asset[]
-  meta?: {
-    pagination: Pagination
-  }
-}
-
-export interface AssetDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Asset
-}
+export type AssetResponse = ApiListResponse<Asset>
+export type AssetDetailResponse = ApiDetailResponse<Asset>
 
 export type { Pagination }

--- a/app/types/assetHolder.ts
+++ b/app/types/assetHolder.ts
@@ -1,5 +1,5 @@
 import type { Employee } from './employee'
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface AssetHolder {
   id: string
@@ -26,21 +26,7 @@ export interface ReturnAssetHolderPayload {
   attachments?: File[]
 }
 
-export interface AssetHolderResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetHolder[]
-  meta?: {
-    pagination: Pagination
-  }
-}
-
-export interface AssetHolderDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetHolder
-}
+export type AssetHolderResponse = ApiListResponse<AssetHolder>
+export type AssetHolderDetailResponse = ApiDetailResponse<AssetHolder>
 
 export type { Pagination }

--- a/app/types/assetLocation.ts
+++ b/app/types/assetLocation.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, Pagination } from './api'
 
 export interface CreateAssetLocationPayload {
   locationId: string
@@ -15,14 +15,6 @@ export interface AssetLocation {
   location: AssetLocationDetail
 }
 
-export interface AssetLocationResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetLocation[]
-  meta: {
-    pagination: Pagination
-  }
-}
+export type AssetLocationResponse = ApiListResponse<AssetLocation>
 
 export type { Pagination }

--- a/app/types/assetMaintenance.ts
+++ b/app/types/assetMaintenance.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface AssetMaintenance {
   id: string
@@ -17,21 +17,7 @@ export interface CreateAssetMaintenancePayload {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UpdateAssetMaintenancePayload extends Partial<CreateAssetMaintenancePayload> {}
 
-export interface AssetMaintenanceResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetMaintenance[]
-  meta?: {
-    pagination: Pagination
-  }
-}
-
-export interface AssetMaintenanceDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetMaintenance
-}
+export type AssetMaintenanceResponse = ApiListResponse<AssetMaintenance>
+export type AssetMaintenanceDetailResponse = ApiDetailResponse<AssetMaintenance>
 
 export type { Pagination }

--- a/app/types/assetNote.ts
+++ b/app/types/assetNote.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface AssetNote {
   id: string
@@ -17,21 +17,7 @@ export interface CreateAssetNotePayload {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UpdateAssetNotePayload extends Partial<CreateAssetNotePayload> {}
 
-export interface AssetNoteResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetNote[]
-  meta?: {
-    pagination: Pagination
-  }
-}
-
-export interface AssetNoteDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: AssetNote
-}
+export type AssetNoteResponse = ApiListResponse<AssetNote>
+export type AssetNoteDetailResponse = ApiDetailResponse<AssetNote>
 
 export type { Pagination }

--- a/app/types/book.ts
+++ b/app/types/book.ts
@@ -18,12 +18,9 @@ export interface BookData {
   }
 }
 
-export interface BookResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: BookData
-}
+import type { ApiListResponse, ApiDetailResponse } from './api'
+
+export type BookResponse = ApiDetailResponse<BookData>
 
 export interface LoanData {
   id: string
@@ -36,9 +33,4 @@ export interface LoanData {
   asset: BookData
 }
 
-export interface LoanListResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: LoanData[]
-}
+export type LoanListResponse = ApiListResponse<LoanData>

--- a/app/types/branch.ts
+++ b/app/types/branch.ts
@@ -1,10 +1,8 @@
+import type { ApiListResponse } from './api'
+
 export interface Branch {
   branchId: string
   name: string
 }
-export interface BranchResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Branch[]
-}
+
+export type BranchResponse = ApiListResponse<Branch>

--- a/app/types/category.ts
+++ b/app/types/category.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface Category {
   data?: any
@@ -9,22 +9,8 @@ export interface Category {
   hasHolder: boolean
 }
 
-export interface CategoryResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Category[]
-  meta: {
-    pagination: Pagination
-  }
-}
-
-export interface CategoryDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Category
-}
+export type CategoryResponse = ApiListResponse<Category>
+export type CategoryDetailResponse = ApiDetailResponse<Category>
 
 export interface CreateCategoryPayload {
   name: string

--- a/app/types/employee.ts
+++ b/app/types/employee.ts
@@ -1,4 +1,5 @@
 import type { Branch } from './branch'
+import type { ApiListResponse } from './api'
 
 export interface Employee {
   employeeId: string
@@ -9,9 +10,4 @@ export interface Employee {
   photoProfile: string
   branch: Branch
 }
-export interface EmployeeResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Employee[]
-}
+export type EmployeeResponse = ApiListResponse<Employee>

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export type FeedbackType = 'keluhan' | 'saran' | 'pujian'
 
@@ -52,16 +52,8 @@ export interface FeedbackRaw {
   reply: string
 }
 
-export interface FeedbackDetailResponse {
-  data: Feedback
-}
-
-export interface FeedbackResponse {
-  data: FeedbackRaw[]
-  meta?: {
-    pagination: Pagination
-  }
-}
+export type FeedbackDetailResponse = ApiDetailResponse<Feedback>
+export type FeedbackResponse = ApiListResponse<FeedbackRaw>
 
 export interface CreateFeedbackPayload {
   url: string

--- a/app/types/location.ts
+++ b/app/types/location.ts
@@ -1,5 +1,5 @@
 import type { Branch } from './branch'
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface Location {
   locationUuid: any
@@ -8,22 +8,8 @@ export interface Location {
   branch: Branch
 }
 
-export interface LocationResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Location[]
-  meta: {
-    pagination: Pagination
-  }
-}
-
-export interface LocationDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Location
-}
+export type LocationResponse = ApiListResponse<Location>
+export type LocationDetailResponse = ApiDetailResponse<Location>
 
 export interface CreateLocationPayload {
   name: string

--- a/app/types/property.ts
+++ b/app/types/property.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface Property {
   id: string
@@ -15,21 +15,7 @@ export interface UpdatePropertyPayload extends Partial<CreatePropertyPayload> {
   id?: string
 }
 
-export interface PropertyResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Property[]
-  meta?: {
-    pagination?: Pagination
-  }
-}
-
-export interface PropertyDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: Property
-}
+export type PropertyResponse = ApiListResponse<Property>
+export type PropertyDetailResponse = ApiDetailResponse<Property>
 
 export type { Pagination }

--- a/app/types/statistic.ts
+++ b/app/types/statistic.ts
@@ -1,9 +1,6 @@
-export interface ApiResponse<T> {
-  success: boolean
-  statusCode: number
-  message: string
-  data: T
-}
+import type { ApiDetailResponse } from './api'
+
+type ApiResponse<T> = ApiDetailResponse<T>
 
 // ---- Count ----
 export interface CountData {

--- a/app/types/subCategory.ts
+++ b/app/types/subCategory.ts
@@ -1,4 +1,4 @@
-import type { Pagination } from './api'
+import type { ApiListResponse, ApiDetailResponse, Pagination } from './api'
 
 export interface AssetProperty {
   id: string
@@ -39,35 +39,9 @@ export interface UpdateSubCategoryPayload {
   labels?: string[]
 }
 
-export interface SubCategoryResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: SubCategory[]
-  meta: {
-    pagination: Pagination
-  }
-}
-
-export interface SubCategoryDetailResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: SubCategory
-}
-
-export interface SubCategoryHierarchyResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: SubCategory[]
-}
-
-export interface SubCategoryPathResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: SubCategory[]
-}
+export type SubCategoryResponse = ApiListResponse<SubCategory>
+export type SubCategoryDetailResponse = ApiDetailResponse<SubCategory>
+export type SubCategoryHierarchyResponse = ApiListResponse<SubCategory>
+export type SubCategoryPathResponse = ApiListResponse<SubCategory>
 
 export type { Pagination }

--- a/app/types/userAsset.ts
+++ b/app/types/userAsset.ts
@@ -1,5 +1,5 @@
 import type { Asset } from './asset'
-import type { Pagination } from './api'
+import type { ApiListResponse, Pagination } from './api'
 
 export interface UserAsset {
   id: string
@@ -12,12 +12,4 @@ export interface UserAsset {
   asset: Partial<Asset>
 }
 
-export interface UserAssetResponse {
-  success: boolean
-  statusCode: number
-  message: string
-  data: UserAsset[]
-  meta: {
-    pagination: Pagination
-  }
-}
+export type UserAssetResponse = ApiListResponse<UserAsset>


### PR DESCRIPTION
## Summary

- Replace all local response wrapper interfaces (`XyzResponse`, `XyzDetailResponse`) with type aliases using shared generics `ApiListResponse<T>` / `ApiDetailResponse<T>` from `app/types/api.ts`
- Covers 15 type files: `asset`, `assetHolder`, `assetLocation`, `assetMaintenance`, `assetNote`, `book`, `branch`, `category`, `employee`, `feedback`, `location`, `property`, `statistic`, `subCategory`, `userAsset`
- Fix 4 composables (`useCategory`, `useLocation`, `useSubCategory`, `useUserAsset`) that accessed `res.meta.pagination` without null guards — updated to `res.meta?.pagination ?? null` since `meta` is optional in `ApiListResponse<T>`
- Update `AssetStatusService.ts` method signatures to use shared types

## Result

- 222 lines removed, 58 added (net -164 lines)
- Zero new TypeScript errors introduced (4 pre-existing errors unchanged)
- Full backward compatibility preserved — all named response types remain as type aliases

## Test plan

- [x] `npx nuxi typecheck` — only 4 pre-existing errors, no new errors
- [x] All composables and services compile correctly with updated types

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)