### PR TITLE
refactor(utils): Utilities Extraction — Formatters, Date & Error Handler (#74)

### DIFF
--- a/app/components/asset/AddModal.vue
+++ b/app/components/asset/AddModal.vue
@@ -9,6 +9,7 @@ import { useProperty } from '~/composables/useProperty'
 import { useLocation } from '~/composables/useLocation'
 import { useAssetLocation } from '~/composables/useAssetLocation'
 import { useBranch } from '~/composables/useBranch'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const props = defineProps<{
   initialCode?: string
@@ -130,26 +131,9 @@ function handlePriceInput(value: string) {
   displayPrice.value = digits ? Number(digits).toLocaleString('id-ID') : ''
 }
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(purchaseDateModel, (newDate) => {
   if (newDate) {
-    state.purchaseDate = calendarDateToString(newDate)
+    state.purchaseDate = calendarDateToISOString(newDate)
   } else {
     state.purchaseDate = ''
   }
@@ -1019,7 +1003,7 @@ onBeforeUnmount(() => {
                 block
                 class="justify-start"
               >
-                {{ formatDateDisplay(purchaseDateModel) }}
+                {{ formatCalendarDate(purchaseDateModel) }}
               </UButton>
               <template #content>
                 <UCalendar v-model="purchaseDateModel" class="p-2" />

--- a/app/components/asset/UpdateModal.vue
+++ b/app/components/asset/UpdateModal.vue
@@ -6,6 +6,7 @@ import { CalendarDate } from '@internationalized/date'
 import { useSubCategory } from '~/composables/useSubCategory'
 import { useAsset } from '~/composables/useAsset'
 import { useProperty } from '~/composables/useProperty'
+import { formatCalendarDate, calendarDateToISOString } from '~/utils/date'
 
 const schema = z.object({
   code: z.string().min(1, 'Asset code is required'),
@@ -125,26 +126,9 @@ function handlePriceInput(value: string) {
   displayPrice.value = digits ? Number(digits).toLocaleString('id-ID') : ''
 }
 
-function formatDateDisplay(date: any): string {
-  if (!date) return 'Select a date'
-  
-  const day = String(date.day).padStart(2, '0')
-  const month = String(date.month).padStart(2, '0')
-  const year = date.year
-  
-  return `${day}/${month}/${year}`
-}
-
-function calendarDateToString(date: any): string {
-  const year = date.year
-  const month = String(date.month).padStart(2, '0')
-  const day = String(date.day).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 watch(purchaseDateModel, (newDate) => {
   if (newDate) {
-    state.purchaseDate = calendarDateToString(newDate)
+    state.purchaseDate = calendarDateToISOString(newDate)
   } else {
     state.purchaseDate = ''
   }
@@ -886,7 +870,7 @@ onBeforeUnmount(() => {
                 block
                 class="justify-start"
               >
-                {{ formatDateDisplay(purchaseDateModel) }}
+                {{ formatCalendarDate(purchaseDateModel) }}
               </UButton>
               <template #content>
                 <UCalendar v-model="purchaseDateModel" class="p-2" />

--- a/app/pages/asset/[id]/detail.vue
+++ b/app/pages/asset/[id]/detail.vue
@@ -3,7 +3,7 @@ import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 import { useAssetHolder } from '~/composables/useAssetHolder'
 import { useAssetMaintenance } from '~/composables/useAssetMaintenance'
-import { formatCurrency } from '~/utils/formatters'
+import { formatCurrency, formatStatusLabel, getStatusColor } from '~/utils/formatters'
 
 const UAvatar = resolveComponent('UAvatar')
 const UBadge = resolveComponent('UBadge')
@@ -138,13 +138,7 @@ const statusColumns: TableColumn<any>[] = [
     header: 'Status',
     cell: ({ row }) => {
       const type = (row.original as any).type
-      const colorMap: Record<string, 'success' | 'error' | 'warning' | 'primary' | 'neutral'> = {
-        'active': 'success',
-        'disposed': 'error',
-        'sold': 'warning',
-        'granted': 'primary'
-      }
-      return h(UBadge, { class: 'capitalize', variant: 'subtle', color: colorMap[type] || 'neutral', size: 'sm' }, () => type.replace('_', ' '))
+      return h(UBadge, { class: 'capitalize', variant: 'subtle', color: getStatusColor(type), size: 'sm' }, () => formatStatusLabel(type))
     }
   },
   { 
@@ -177,6 +171,25 @@ function getIconByLogType(type: string): string {
     case 'note': return 'i-lucide-notebook-pen'
     default: return 'i-lucide-history'
   }
+}
+
+const STATUS_ICON_MAP: Record<string, string> = {
+  active: 'i-lucide-check-circle',
+  disposed: 'i-lucide-trash-2',
+  sold: 'i-lucide-shopping-cart',
+  granted: 'i-lucide-gift'
+}
+const STATUS_TEXT_COLOR_MAP: Record<string, string> = {
+  active: 'text-green-500',
+  disposed: 'text-red-500'
+}
+
+function getStatusIcon(status: string): string {
+  return STATUS_ICON_MAP[status] ?? 'i-lucide-info'
+}
+
+function getStatusTextColor(status: string): string {
+  return STATUS_TEXT_COLOR_MAP[status] ?? 'text-yellow-500'
 }
 
 async function loadLogs() {
@@ -364,12 +377,12 @@ async function loadLogs() {
                       <UTooltip :text="assetDetail.lastStatus?.note || 'No note provided'" :disabled="!assetDetail.lastStatus?.note">
                         <div class="flex items-center gap-2">
                           <UIcon
-                            :name="assetDetail.lastStatus?.type === 'active' ? 'i-lucide-check-circle' : assetDetail.lastStatus?.type === 'disposed' ? 'i-lucide-trash-2' : assetDetail.lastStatus?.type === 'sold' ? 'i-lucide-shopping-cart' : assetDetail.lastStatus?.type === 'granted' ? 'i-lucide-gift' : 'i-lucide-info'"
-                            :class="assetDetail.lastStatus?.type === 'active' ? 'text-green-500' : assetDetail.lastStatus?.type === 'disposed' ? 'text-red-500' : 'text-yellow-500'"
+                            :name="getStatusIcon(assetDetail.lastStatus?.type ?? '')"
+                            :class="getStatusTextColor(assetDetail.lastStatus?.type ?? '')"
                             class="w-4 h-4"
                           />
                           <span class="text-gray-900 dark:text-white text-sm capitalize">
-                            {{ assetDetail.lastStatus?.type ? assetDetail.lastStatus.type.replace('_', ' ') : '-' }}
+                            {{ assetDetail.lastStatus?.type ? formatStatusLabel(assetDetail.lastStatus.type) : '-' }}
                           </span>
                         </div>
                       </UTooltip>

--- a/app/pages/asset/index.vue
+++ b/app/pages/asset/index.vue
@@ -10,6 +10,7 @@ import { useCategory } from '~/composables/useCategory'
 import { useEmployee } from '~/composables/useEmployee'
 import { useLocation } from '~/composables/useLocation'
 import { useRole } from '~/composables/useRole'
+import { formatStatusLabel, getStatusColor } from '~/utils/formatters'
 
 interface EmployeeItem {
   id: string
@@ -862,22 +863,10 @@ const columns: TableColumn<any>[] = [
       const statusType = row.original.lastStatus?.type
       if (!statusType) return h('span', { class: 'text-xs text-muted' }, '-')
 
-      const colorMap: Record<string, 'success' | 'error' | 'warning' | 'primary' | 'neutral'> = {
-        'active': 'success',
-        'disposed': 'error',
-        'sold': 'warning',
-        'granted': 'primary'
-      }
-      
-      const displayStatus = statusType
-        .split('_')
-        .map((s: string) => s.charAt(0).toUpperCase() + s.slice(1))
-        .join(' ')
-        
       return h(
         UBadge,
-        { class: 'capitalize', variant: 'subtle', color: colorMap[statusType] || 'neutral' },
-        () => displayStatus
+        { class: 'capitalize', variant: 'subtle', color: getStatusColor(statusType) },
+        () => formatStatusLabel(statusType)
       )
     }
   },

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,3 +1,22 @@
+export function formatDate(date: string | Date): string {
+  if (!date) return '-'
+  const d = typeof date === 'string' ? new Date(date) : date
+  const day = String(d.getDate()).padStart(2, '0')
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  return `${day}/${month}/${d.getFullYear()}`
+}
+
+export function toGMT7(date: Date): Date {
+  const utc = date.getTime() + date.getTimezoneOffset() * 60000
+  return new Date(utc + 7 * 3600000)
+}
+
+export function toISOLocal(date: Date): string {
+  const d = toGMT7(date)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
 export function formatCalendarDate(date: { day: number, month: number, year: number } | null): string {
   if (!date) return 'Select a date'
   const day = String(date.day).padStart(2, '0')

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -11,3 +11,18 @@ export function formatCurrency(value: number | string | null | undefined): strin
 export function formatNumber(value: number): string {
   return value.toLocaleString('en-US')
 }
+
+export function formatStatusLabel(status: string): string {
+  return status.split('_').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')
+}
+
+const STATUS_COLOR_MAP: Record<string, 'success' | 'error' | 'warning' | 'primary' | 'neutral'> = {
+  active: 'success',
+  disposed: 'error',
+  sold: 'warning',
+  granted: 'primary'
+}
+
+export function getStatusColor(status: string): 'success' | 'error' | 'warning' | 'primary' | 'neutral' {
+  return STATUS_COLOR_MAP[status] ?? 'neutral'
+}


### PR DESCRIPTION
## Summary

- Add `formatDate`, `toGMT7`, `toISOLocal` to `app/utils/date.ts`
- Add `formatStatusLabel`, `getStatusColor` to `app/utils/formatters.ts`
- Remove all inline `formatDateDisplay` / `calendarDateToString` duplications from `AddModal.vue` and `UpdateModal.vue` — replaced with shared imports from `~/utils/date`
- Replace duplicated `colorMap` + `displayStatus` logic in `asset/index.vue` and `asset/[id]/detail.vue` with `formatStatusLabel` / `getStatusColor` from `~/utils/formatters`
- `app/utils/errorHandler.ts` was already extracted in PR #78

## Result

- Zero new TypeScript errors (4 pre-existing errors unchanged)
- All formatter behavior preserved — same output format for dates and currency
- Status label/color logic now has a single source of truth

## Test plan

- [x] `npx nuxi typecheck` — only 4 pre-existing errors, no new errors
- [x] `formatCalendarDate` still returns `dd/mm/yyyy` format (same as removed `formatDateDisplay`)
- [x] `getStatusColor` returns same badge colors as the removed inline `colorMap`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)