### PR TITLE
refactor(services): Service Layer — BaseService & Filter Objects (#75)

### DIFF
--- a/app/composables/useAssetStatus.ts
+++ b/app/composables/useAssetStatus.ts
@@ -35,7 +35,7 @@ export function useAssetStatus() {
     loading.value = true
     error.value = null
     try {
-      const res = await assetStatusService.getStatuses(assetUuid, page, limit, search)
+      const res = await assetStatusService.getStatuses(assetUuid, { page, limit, search })
       statuses.value = res.data
       return res
     } catch (err: unknown) {

--- a/app/composables/useCategory.ts
+++ b/app/composables/useCategory.ts
@@ -50,7 +50,7 @@ export function useCategory(): CategoryState {
     loading.value = true
     error.value = null
     try {
-      const res = await categoryService.getCategories(search, page, limit)
+      const res = await categoryService.getCategories({ search, page, limit })
       categories.value = res.data
       apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {

--- a/app/composables/useFeedback.ts
+++ b/app/composables/useFeedback.ts
@@ -37,7 +37,7 @@ export function useFeedback(): FeedbackState {
     loading.value = true
     error.value = null
     try {
-      const res = await feedbackService.getFeedbacks(search, page, limit, byUser)
+      const res = await feedbackService.getFeedbacks({ search, page, limit, byUser })
       feedbacks.value = res.data.map((raw: FeedbackRaw): Feedback => ({
         type: raw.category,
         description: raw.message,

--- a/app/composables/useLocation.ts
+++ b/app/composables/useLocation.ts
@@ -48,7 +48,7 @@ export function useLocation(): LocationState {
     loading.value = true
     error.value = null
     try {
-      const res = await locationService.getLocations(search, page, limit)
+      const res = await locationService.getLocations({ search, page, limit })
       locations.value = res.data
       apiPagination.value = res.meta?.pagination ?? null
       pagination.value.pageIndex = page - 1

--- a/app/composables/useSubCategory.ts
+++ b/app/composables/useSubCategory.ts
@@ -53,7 +53,7 @@ export function useSubCategory(): SubCategoryState {
     loading.value = true
     error.value = null
     try {
-      const res = await subCategoryService.getSubCategories(search, page, limit, categoryUuid)
+      const res = await subCategoryService.getSubCategories({ search, page, limit, categoryUuid })
       subCategories.value = res.data
       apiPagination.value = res.meta?.pagination ?? null
     } catch (err: unknown) {

--- a/app/services/AssetStatusService.ts
+++ b/app/services/AssetStatusService.ts
@@ -28,7 +28,8 @@ export class AssetStatusService extends BaseService {
     })
   }
 
-  async getStatuses(assetUuid: string, page = 1, limit = 10, search = ''): Promise<ApiListResponse<AssetStatusResponse>> {
+  async getStatuses(assetUuid: string, options: { page?: number, limit?: number, search?: string } = {}): Promise<ApiListResponse<AssetStatusResponse>> {
+    const { page = 1, limit = 10, search = '' } = options
     return await this.api<ApiListResponse<AssetStatusResponse>>(`${this.basePath}/${assetUuid}/status`, {
       method: 'GET',
       params: { page, limit, search },

--- a/app/services/CategoryService.ts
+++ b/app/services/CategoryService.ts
@@ -1,11 +1,12 @@
 import { BaseService } from '~/services/base'
-import type { Category, CategoryDetailResponse, CategoryResponse, CreateCategoryPayload, UpdateCategoryPayload } from '~/types/category'
+import type { Category, CategoryDetailResponse, CategoryFilterOptions, CategoryResponse, CreateCategoryPayload, UpdateCategoryPayload } from '~/types/category'
 import type { SubCategoryResponse } from '~/types/subCategory'
 
 export class CategoryService extends BaseService {
   private basePath = '/v1/category'
 
-  async getCategories(search = '', page = 1, limit = 10): Promise<CategoryResponse> {
+  async getCategories(options: CategoryFilterOptions = {}): Promise<CategoryResponse> {
+    const { search = '', page = 1, limit = 10 } = options
     return await this.api<CategoryResponse>(this.basePath, {
       method: 'GET',
       params: { search, page, limit },

--- a/app/services/FeedbackService.ts
+++ b/app/services/FeedbackService.ts
@@ -2,6 +2,7 @@ import { BaseService } from '~/services/base'
 import type {
   Feedback,
   FeedbackDetailResponse,
+  FeedbackFilterOptions,
   FeedbackResponse,
   CreateFeedbackPayload,
   UpdateFeedbackPayload
@@ -10,7 +11,8 @@ import type {
 export class FeedbackService extends BaseService {
   private basePath = '/feedback'
 
-  async getFeedbacks(search = '', page = 1, limit = 10, byUser = true): Promise<FeedbackResponse> {
+  async getFeedbacks(options: FeedbackFilterOptions = {}): Promise<FeedbackResponse> {
+    const { search = '', page = 1, limit = 10, byUser = true } = options
     return await this.api<FeedbackResponse>(this.basePath, {
       method: 'GET',
       params: { search, page, limit, 'by-user': byUser },

--- a/app/services/LocationService.ts
+++ b/app/services/LocationService.ts
@@ -1,10 +1,11 @@
 import { BaseService } from '~/services/base'
-import type { LocationDetailResponse, LocationResponse, CreateLocationPayload, UpdateLocationPayload } from '~/types/location'
+import type { LocationDetailResponse, LocationFilterOptions, LocationResponse, CreateLocationPayload, UpdateLocationPayload } from '~/types/location'
 
 export class LocationService extends BaseService {
   private basePath = '/v1/location'
 
-  async getLocations(search = '', page = 1, limit = 10): Promise<LocationResponse> {
+  async getLocations(options: LocationFilterOptions = {}): Promise<LocationResponse> {
+    const { search = '', page = 1, limit = 10 } = options
     return await this.api<LocationResponse>(this.basePath, {
       method: 'GET',
       params: { search, page, limit },

--- a/app/services/PropertyService.ts
+++ b/app/services/PropertyService.ts
@@ -2,6 +2,7 @@ import { BaseService } from '~/services/base'
 import type {
   Property,
   PropertyDetailResponse,
+  PropertyFilterOptions,
   PropertyResponse,
   CreatePropertyPayload,
   UpdatePropertyPayload
@@ -10,7 +11,8 @@ import type {
 export class PropertyService extends BaseService {
   private basePath = '/v1/sub-category'
 
-  async getProperties(subCategoryId: string, search = '', page = 1, limit = 10): Promise<PropertyResponse> {
+  async getProperties(subCategoryId: string, options: PropertyFilterOptions = {}): Promise<PropertyResponse> {
+    const { search = '', page = 1, limit = 10 } = options
     return await this.api<PropertyResponse>(`${this.basePath}/${subCategoryId}/property`, {
       method: 'GET',
       params: { search, page, limit },

--- a/app/services/SubCategoryService.ts
+++ b/app/services/SubCategoryService.ts
@@ -2,6 +2,7 @@ import { BaseService } from '~/services/base'
 import type {
   SubCategory,
   SubCategoryDetailResponse,
+  SubCategoryFilterOptions,
   SubCategoryResponse,
   SubCategoryHierarchyResponse,
   SubCategoryPathResponse,
@@ -12,7 +13,8 @@ import type {
 export class SubCategoryService extends BaseService {
   private basePath = '/v1/sub-category'
 
-  async getSubCategories(search = '', page = 1, limit = 10, categoryUuid?: string): Promise<SubCategoryResponse> {
+  async getSubCategories(options: SubCategoryFilterOptions = {}): Promise<SubCategoryResponse> {
+    const { search = '', page = 1, limit = 10, categoryUuid } = options
     const params: Record<string, any> = { search, page, limit }
     if (categoryUuid) params.categoryUuid = categoryUuid
     return await this.api<SubCategoryResponse>(this.basePath, {

--- a/app/types/category.ts
+++ b/app/types/category.ts
@@ -12,6 +12,12 @@ export interface Category {
 export type CategoryResponse = ApiListResponse<Category>
 export type CategoryDetailResponse = ApiDetailResponse<Category>
 
+export interface CategoryFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+}
+
 export interface CreateCategoryPayload {
   name: string
   hasLocation: boolean

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -55,6 +55,13 @@ export interface FeedbackRaw {
 export type FeedbackDetailResponse = ApiDetailResponse<Feedback>
 export type FeedbackResponse = ApiListResponse<FeedbackRaw>
 
+export interface FeedbackFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+  byUser?: boolean
+}
+
 export interface CreateFeedbackPayload {
   url: string
   type: FeedbackType

--- a/app/types/location.ts
+++ b/app/types/location.ts
@@ -11,6 +11,12 @@ export interface Location {
 export type LocationResponse = ApiListResponse<Location>
 export type LocationDetailResponse = ApiDetailResponse<Location>
 
+export interface LocationFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+}
+
 export interface CreateLocationPayload {
   name: string
   branchId: string

--- a/app/types/property.ts
+++ b/app/types/property.ts
@@ -6,6 +6,12 @@ export interface Property {
   dataType: 'string' | 'number'
 }
 
+export interface PropertyFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+}
+
 export interface CreatePropertyPayload {
   name: string
   dataType: 'string' | 'number'

--- a/app/types/subCategory.ts
+++ b/app/types/subCategory.ts
@@ -25,6 +25,13 @@ export interface SubCategory {
   labels?: string[]
 }
 
+export interface SubCategoryFilterOptions {
+  search?: string
+  page?: number
+  limit?: number
+  categoryUuid?: string
+}
+
 export interface CreateSubCategoryPayload {
   name: string
   categoryId: string


### PR DESCRIPTION
## Summary

- `BaseService` with `getAuthHeader()` and all services extending it were already in place from prior work
- `AssetService.getAssets()` with `AssetFilterOptions` was already implemented
- **New in this PR**: add `XxxFilterOptions` types and convert remaining services that had multiple positional params:
  - `CategoryService.getCategories(search, page, limit)` → `getCategories(options)`
  - `FeedbackService.getFeedbacks(search, page, limit, byUser)` → `getFeedbacks(options)`
  - `LocationService.getLocations(search, page, limit)` → `getLocations(options)`
  - `PropertyService.getProperties(subCategoryId, search, page, limit)` → `getProperties(subCategoryId, options)`
  - `SubCategoryService.getSubCategories(search, page, limit, categoryUuid)` → `getSubCategories(options)`
  - `AssetStatusService.getStatuses(uuid, page, limit, search)` → `getStatuses(uuid, options)`
- Update all composable call sites accordingly

## Result

- Zero new TypeScript errors (4 pre-existing errors unchanged)
- All service method calls now use named options — no more positional argument ordering bugs

## Test plan

- [x] `npx nuxi typecheck` — only 4 pre-existing errors, no new errors
- [x] All composables updated to use object form

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)