### PR TITLE
refactor(composables): Composable Cleanup — Toast Standardization (#76)

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -70,7 +70,7 @@ export function useAuth(): AuthState {
       const res = await authService.login(username, password)
       setTokens(res.data.accessToken, res.data.refreshToken)
       await getMe()
-      toast.add({ title: 'Success', description: 'Logged in successfully' })
+      toast.add({ title: 'Success', description: 'Logged in successfully', color: 'success' })
       return true
     } catch (err: unknown) {
       toast.add({
@@ -87,7 +87,7 @@ export function useAuth(): AuthState {
       const res = await authService.google(code)
       setTokens(res.data.accessToken, res.data.refreshToken)
       await getMe()
-      toast.add({ title: 'Success', description: 'Logged in successfully' })
+      toast.add({ title: 'Success', description: 'Logged in successfully', color: 'success' })
       return true
     } catch (err: unknown) {
       toast.add({

--- a/app/composables/useProperty.ts
+++ b/app/composables/useProperty.ts
@@ -62,6 +62,7 @@ export function useProperty(): PropertyState {
     error.value = null
     try {
       await propertyService.createProperty(subCategoryId, payload)
+      toast.add({ title: 'Created', description: 'Property created successfully', color: 'success' })
     } catch (err: unknown) {
       error.value = extractErrorMessage(err, 'Failed to create property')
       toast.add({ title: 'Create failed', description: error.value, color: 'error' })


### PR DESCRIPTION
## Summary

Most of the Tahap 4 cleanup was already done in prior sessions:
- **T4.1**: All composables already use `extractErrorMessage` — no inline `FetchError` casts remain
- **T4.3**: All composables already use `export function useX()` declaration
- **T4.4**: `useState` is only used in `useAuth` (SSR-safe auth tokens/user) — all others use `ref`
- **T4.5**: Pagination/search boilerplate assessed — not extracting a factory as it would add unnecessary abstraction

**New in this PR:**
- **T4.2**: Add missing `color: 'success'` to login success toasts in `useAuth` (lines 73, 90)
- Add missing success toast for `createProperty` in `useProperty` to match pattern of all other CRUD composables

## Result

- Every `toast.add` call now consistently includes `color: 'success'` or `color: 'error'`
- Zero new TypeScript errors (4 pre-existing errors unchanged)

## Test plan

- [x] `npx nuxi typecheck` — only 4 pre-existing errors, no new errors
- [x] All 105 toast calls audited — all have color field

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)