### PR TITLE
refactor(schemas): extract remaining inline schemas for all domains

### DIFF
--- a/app/components/category/AddModal.vue
+++ b/app/components/category/AddModal.vue
@@ -1,16 +1,7 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useCategory } from '~/composables/useCategory'
-
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  hasLocation: z.boolean().default(false),
-  hasMaintenance: z.boolean().default(false),
-  hasHolder: z.boolean().default(false)
-})
-
-type Schema = z.output<typeof schema>
+import { categorySchema as schema, type CategorySchema as Schema } from '~/schemas/categorySchema'
 
 const emit = defineEmits<{ (e: 'created'): void }>()
 const open = ref(false)

--- a/app/components/category/UpdateModal.vue
+++ b/app/components/category/UpdateModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useCategory } from '~/composables/useCategory'
+import { categorySchema as schema, type CategorySchema as Schema } from '~/schemas/categorySchema'
 
 const props = defineProps<{
   id: string | null
@@ -12,14 +12,6 @@ const emit = defineEmits<{
   (e: 'updated'): void
   (e: 'update:open', value: boolean): void
 }>()
-
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  hasLocation: z.boolean().default(false),
-  hasMaintenance: z.boolean().default(false),
-  hasHolder: z.boolean().default(false)
-})
-type Schema = z.output<typeof schema>
 
 const formData = reactive<Schema>({
   name: '',

--- a/app/components/feedback/ReplyModal.vue
+++ b/app/components/feedback/ReplyModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useFeedback } from '~/composables/useFeedback'
+import { replyFeedbackSchema as schema, type ReplyFeedbackSchema as Schema } from '~/schemas/feedbackSchema'
 
 /** Props */
 const props = defineProps<{
@@ -14,21 +14,6 @@ const emit = defineEmits<{
   (e: 'updated'): void
   (e: 'update:open', value: boolean): void
 }>()
-
-/** Zod schema */
-const schema = z.object({
-  status: z.enum([
-    'new',
-    'ignored',
-    'noted',
-    'need discussion',
-    'accepted',
-    'in progress',
-    'done'
-  ]),
-  reply: z.string().min(1, 'Reply is required')
-})
-type Schema = z.output<typeof schema>
 
 /** Reactive form state */
 const formData = reactive<Schema>({

--- a/app/components/location/AddModal.vue
+++ b/app/components/location/AddModal.vue
@@ -1,15 +1,8 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useLocation } from '~/composables/useLocation'
 import { useBranch } from '~/composables/useBranch'
-
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  branchId: z.string().min(1, 'Branch is required')
-})
-
-type Schema = z.output<typeof schema>
+import { locationSchema as schema, type LocationSchema as Schema } from '~/schemas/locationSchema'
 
 const emit = defineEmits<{ (e: 'created'): void }>()
 

--- a/app/components/location/UpdateModal.vue
+++ b/app/components/location/UpdateModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { reactive, ref, watch } from 'vue'
 import { useLocation } from '~/composables/useLocation'
 import { useBranch } from '~/composables/useBranch'
+import { locationSchema as schema, type LocationSchema as Schema } from '~/schemas/locationSchema'
 
 const props = defineProps<{
   id: string | null
@@ -14,13 +14,6 @@ const emit = defineEmits<{
   (e: 'updated'): void
   (e: 'update:open', value: boolean): void
 }>()
-
-// ✅ schema pakai branchId, sama seperti add
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  branchId: z.string().min(1, 'Branch is required')
-})
-type Schema = z.output<typeof schema>
 
 const formData = reactive<Schema>({
   name: '',

--- a/app/components/subCategory/AddModal.vue
+++ b/app/components/subCategory/AddModal.vue
@@ -1,23 +1,9 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useSubCategory } from '~/composables/useSubCategory'
 import { useCategory } from '~/composables/useCategory'
 import { useProperty } from '~/composables/useProperty'
-
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  categoryId: z.string().min(1, 'Category is required'),
-  labels: z.array(z.string()).optional(),
-  properties: z.array(
-    z.object({
-      name: z.string().min(1, 'Property name is required'),
-      dataType: z.enum(['string', 'number'], { message: 'Type is required' })
-    })
-  )
-})
-
-type Schema = z.output<typeof schema>
+import { createSubCategorySchema as schema, type CreateSubCategorySchema as Schema } from '~/schemas/subCategorySchema'
 
 const emit = defineEmits<{ (e: 'created'): void }>()
 const open = ref(false)

--- a/app/components/subCategory/AddPropertyModal.vue
+++ b/app/components/subCategory/AddPropertyModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useSubCategory } from '~/composables/useSubCategory'
 import { propertyService } from '~/services/PropertyService'
+import { propertySchema as schema, type PropertySchema as Schema } from '~/schemas/subCategorySchema'
 
 const props = defineProps<{
   id: string
@@ -13,12 +13,6 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'updated'): void
 }>()
-
-const schema = z.object({
-  name: z.string().min(1, 'Property name is required'),
-  dataType: z.enum(['string', 'number'], { message: 'Type is required' })
-})
-type Schema = z.output<typeof schema>
 
 // state
 const saving = ref(false)

--- a/app/components/subCategory/UpdateModal.vue
+++ b/app/components/subCategory/UpdateModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { useSubCategory } from '~/composables/useSubCategory'
 import { useCategory } from '~/composables/useCategory'
+import { updateSubCategorySchema as schema, type UpdateSubCategorySchema as Schema } from '~/schemas/subCategorySchema'
 
 const props = defineProps<{
   id: string
@@ -13,14 +13,6 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'updated'): void
 }>()
-
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  categoryId: z.string().min(1, 'Category is required'),
-  labels: z.array(z.string()).optional()
-})
-
-type Schema = z.output<typeof schema>
 
 const saving = ref(false)
 const state = reactive<Partial<Schema>>({

--- a/app/schemas/assetSchema.ts
+++ b/app/schemas/assetSchema.ts
@@ -1,4 +1,10 @@
 import * as z from 'zod'
+import { categorySchema, type CategorySchema } from './categorySchema'
+import { propertySchema } from './subCategorySchema'
+import { locationSchema as assetLocationSchema, type LocationSchema as AssetLocationSchema } from './locationSchema'
+
+export { categorySchema, type CategorySchema }
+export { assetLocationSchema, type AssetLocationSchema }
 
 const propertyEntry = z.object({
   id: z.string(),
@@ -22,6 +28,14 @@ const labelSuperRefine = (data: { labels?: { key: string; value: string }[] }, c
     })
   }
 }
+
+export const subCategorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  categoryId: z.string().min(1, 'Category is required'),
+  properties: z.array(propertySchema)
+})
+
+export type SubCategorySchema = z.infer<typeof subCategorySchema>
 
 export const createAssetSchema = z.object({
   codes: z.array(z.string().min(1, 'Asset code is required')).min(1, 'At least one code is required'),
@@ -64,31 +78,5 @@ export const updateAssetSchema = z.object({
   labels: z.array(labelEntry).optional()
 }).superRefine(labelSuperRefine)
 
-export const categorySchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  hasMaintenance: z.boolean().default(false),
-  hasHolder: z.boolean().default(false),
-  hasLocation: z.boolean().default(false)
-})
-
-export const subCategorySchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  categoryId: z.string().min(1, 'Category is required'),
-  properties: z.array(
-    z.object({
-      name: z.string().min(1, 'Property name is required'),
-      dataType: z.enum(['string', 'number'], { message: 'Type is required' })
-    })
-  )
-})
-
-export const assetLocationSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  branchId: z.string().min(1, 'Branch is required')
-})
-
 export type CreateAssetSchema = z.output<typeof createAssetSchema>
 export type UpdateAssetSchema = z.output<typeof updateAssetSchema>
-export type CategorySchema = z.infer<typeof categorySchema>
-export type SubCategorySchema = z.infer<typeof subCategorySchema>
-export type AssetLocationSchema = z.infer<typeof assetLocationSchema>

--- a/app/schemas/categorySchema.ts
+++ b/app/schemas/categorySchema.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod'
+
+export const categorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  hasLocation: z.boolean().default(false),
+  hasMaintenance: z.boolean().default(false),
+  hasHolder: z.boolean().default(false)
+})
+
+export type CategorySchema = z.output<typeof categorySchema>

--- a/app/schemas/feedbackSchema.ts
+++ b/app/schemas/feedbackSchema.ts
@@ -8,3 +8,10 @@ export const feedbackSchema = z.object({
 })
 
 export type FeedbackSchema = z.infer<typeof feedbackSchema>
+
+export const replyFeedbackSchema = z.object({
+  status: z.enum(['new', 'ignored', 'noted', 'need discussion', 'accepted', 'in progress', 'done']),
+  reply: z.string().min(1, 'Reply is required')
+})
+
+export type ReplyFeedbackSchema = z.output<typeof replyFeedbackSchema>

--- a/app/schemas/locationSchema.ts
+++ b/app/schemas/locationSchema.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod'
+
+export const locationSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  branchId: z.string().min(1, 'Branch is required')
+})
+
+export type LocationSchema = z.output<typeof locationSchema>

--- a/app/schemas/subCategorySchema.ts
+++ b/app/schemas/subCategorySchema.ts
@@ -1,0 +1,23 @@
+import * as z from 'zod'
+
+export const propertySchema = z.object({
+  name: z.string().min(1, 'Property name is required'),
+  dataType: z.enum(['string', 'number'], { message: 'Type is required' })
+})
+
+export const createSubCategorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  categoryId: z.string().min(1, 'Category is required'),
+  labels: z.array(z.string()).optional(),
+  properties: z.array(propertySchema)
+})
+
+export const updateSubCategorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  categoryId: z.string().min(1, 'Category is required'),
+  labels: z.array(z.string()).optional()
+})
+
+export type PropertySchema = z.output<typeof propertySchema>
+export type CreateSubCategorySchema = z.output<typeof createSubCategorySchema>
+export type UpdateSubCategorySchema = z.output<typeof updateSubCategorySchema>


### PR DESCRIPTION
Add categorySchema.ts, locationSchema.ts, subCategorySchema.ts with domain schemas. Add replyFeedbackSchema to feedbackSchema.ts. Refactor assetSchema.ts to import shared schemas from domain files instead of redefining them. Update category, location, subCategory, and feedback/ReplyModal components to import from app/schemas/ — no inline z.object() declarations remain in any component.